### PR TITLE
Add Node Provision and Unprovision Functionality

### DIFF
--- a/esi_ui/api/esi_api.py
+++ b/esi_ui/api/esi_api.py
@@ -6,6 +6,8 @@ from django.conf import settings
 from esi import connection
 from esi.lib import nodes
 
+from metalsmith import _provisioner
+from metalsmith import instance_config
 from openstack import config
 from horizon.utils.memoized import memoized  # noqa
 
@@ -87,6 +89,26 @@ def node_list(request):
                                             + ' (%s)' % ','.join(pfws) if pfws else '')
 
     return node_infos
+
+
+def deploy_node(request, node):
+    token = request.user.token.id
+    kwargs = json.loads(request.body.decode('utf-8'))
+
+    provisioner = _provisioner.Provisioner(session=get_session_from_token(token))
+    
+    if 'ssh_keys' in kwargs:
+        kwargs['config'] = instance_config.GenericConfig(ssh_keys=kwargs['ssh_keys'])
+        del kwargs['ssh_keys']
+
+    provisioner.provision_node(node, **kwargs)
+
+
+def undeploy_node(request, node):
+    token = request.user.token.id
+    provisioner = _provisioner.Provisioner(session=get_session_from_token(token))
+
+    provisioner.unprovision_node(node, wait=None)
 
 
 def set_power_state(request, node, target):

--- a/esi_ui/api/esi_rest_api.py
+++ b/esi_ui/api/esi_rest_api.py
@@ -22,6 +22,27 @@ class Nodes(generic.View):
             'nodes': nodes
         }
 
+
+@urls.register
+class Deploy(generic.View):
+
+    url_regex = r'esi/nodes/(?P<node>{})/deploy/$'.format(LOGICAL_NAME_PATTERN)
+
+    @rest_utils.ajax(data_required=True)
+    def put(self, request, node):
+        esi_api.deploy_node(request, node)
+
+
+@urls.register
+class Undeploy(generic.View):
+
+    url_regex = r'esi/nodes/(?P<node>{})/undeploy/$'.format(LOGICAL_NAME_PATTERN)
+
+    @rest_utils.ajax()
+    def put(self, request, node):
+        esi_api.undeploy_node(request, node)
+
+
 @urls.register
 class StatesPower(generic.View):
 

--- a/esi_ui/static/dashboard/project/esi/esi.module.js
+++ b/esi_ui/static/dashboard/project/esi/esi.module.js
@@ -19,14 +19,14 @@
         {id: 'provision_state', title: 'Provision State', priority: 1},
         {id: 'power_state', title: 'Power State', priority: 1},
         {id: 'maintenance', title: 'Maintenance', priority: 1},
-        {id: 'status', title: 'Status', priority: 1},
+        {id: 'status', title: 'Lease Status', priority: 1},
       ],
       lease_details: [
         {id: 'lessee', title: 'Lessee', priority: 1},
         {id: 'owner', title: 'Owner', priority: 1},
         {id: 'resource_class', title: 'Resource Class', priority: 1},
-        {id: 'start_time', title: 'Start Time', priority: 1},
-        {id: 'end_time', title: 'End Time', priority: 1},
+        {id: 'start_time', title: 'Start Time (UTC)', priority: 1},
+        {id: 'end_time', title: 'End Time (UTC)', priority: 1},
         {id: 'lease_uuid', title: 'Lease UUID', priority: 1},
         {id: 'properties', title: 'Properties', priority: 1},
       ],
@@ -97,6 +97,11 @@
       {
         label: gettext('Maintenance'),
         name: 'maintenance',
+        singleton: true
+      },
+      {
+        label: gettext('Lease Status'),
+        name: 'status',
         singleton: true
       },
       {

--- a/esi_ui/static/dashboard/project/esi/forms/provision-modal-form.controller.js
+++ b/esi_ui/static/dashboard/project/esi/forms/provision-modal-form.controller.js
@@ -1,0 +1,69 @@
+(function () {
+  'use strict';
+
+  angular
+    .module('horizon.dashboard.project.esi')
+    .controller('horizon.dashboard.project.esi.ProvisionModalFormController', controller);
+
+  controller.$inject = [
+    '$uibModalInstance',
+    'horizon.framework.util.http.service',
+  ];
+
+  function controller($uibModalInstance, apiService) {
+    var ctrl = this;
+
+    ctrl.formTitle = 'Provision Nodes';
+    ctrl.submitText = 'Submit';
+    ctrl.images = null
+    ctrl.networks = null
+    ctrl.ssh_keys = null
+    ctrl.selected = {
+      image: null,
+      nics: null,
+      ssh_keys: null,
+    }
+
+    ctrl.submit = submit;
+
+    ////////////////
+
+    init()
+
+    function init() {
+      apiService.get('/api/glance/images/')
+      .then(function(response) {
+        ctrl.images = response.data.items.map(function(image) {
+          return image.name;
+        });
+      });
+
+      apiService.get('/api/neutron/networks/')
+      .then(function(response) {
+        ctrl.networks = response.data.items.map(function(network) {
+          return network.name;
+        });
+      });
+
+      apiService.get('/api/nova/keypairs/')
+      .then(function(response) {
+        console.log(response);
+        ctrl.ssh_keys = response.data.items.map(function(keypair) {
+          return keypair.keypair;
+        });
+      });
+    }
+
+    function submit($event) {
+      $event.preventDefault();
+      $event.stopPropagation();
+
+      ctrl.selected.nics = [{network: ctrl.selected.nics}];
+      
+      ctrl.selected.ssh_keys = [ctrl.selected.ssh_keys.public_key.trim()];
+
+      return $uibModalInstance.close(ctrl.selected);
+    }
+  }
+
+})();

--- a/esi_ui/static/dashboard/project/esi/forms/provision-modal-form.html
+++ b/esi_ui/static/dashboard/project/esi/forms/provision-modal-form.html
@@ -1,0 +1,79 @@
+<div class="modal-header">
+  <a class="close" ng-click="$dismiss()">
+    <span class="fa fa-times"></span>
+  </a>
+  <div class="h4 modal-title">
+    {$::ctrl.formTitle$}
+  </div>
+</div>
+
+<div class="modal-body">
+  <div style="width: 100%; display: flex; flex-direction: column">
+    <div class="form-group">
+      <label for="image_name">
+        {$ ::'Image Name' | translate $}
+        <span class="hz-icon-required fa fa-asterisk"></span>
+      </label>
+      <br>
+      <div ng-if="ctrl.images === null" style="width: 100%; text-align: center">
+        <span class="fa fa-spinner fa-spin fa-2x"></span>
+      </div>
+      <select class="form-control"
+              ng-if="ctrl.images !== null"
+              name="image_name"
+              ng-model="ctrl.selected.image"
+              required
+              ng-options="image for image in ctrl.images">
+      </select>
+    </div>
+
+    <div class="form-group">
+      <label for="networks">
+        {$ ::'Networks' | translate $}
+      </label>
+      <br>
+      <div ng-if="ctrl.networks === null" style="width: 100%; text-align: center">
+        <span class="fa fa-spinner fa-spin fa-2x"></span>
+      </div>
+      <select class="form-control"
+              ng-if="ctrl.networks !== null"
+              name="networks"
+              ng-model="ctrl.selected.nics"
+              ng-options="network for network in ctrl.networks">
+        <option value=""></option>
+      </select>
+    </div>
+
+    <div class="form-group">
+      <label for="ssh_keys">
+        {$ ::'SSH Keys' | translate $}
+      </label>
+      <br>
+      <div ng-if="ctrl.ssh_keys === null" style="width: 100%; text-align: center">
+        <span class="fa fa-spinner fa-spin fa-2x"></span>
+      </div>
+      <select class="form-control"
+              ng-if="ctrl.ssh_keys !== null"
+              name="ssh_keys"
+              ng-model="ctrl.selected.ssh_keys"
+              ng-options="key.name for key in ctrl.ssh_keys">
+        <option value=""></option>
+      </select>
+    </div>
+  </div>
+</div>
+
+<div class="modal-footer">
+  <button type="button" class="btn btn-default pull-left" ng-click="$dismiss()">
+    <span class="fa fa-close"></span>
+    <translate>Cancel</translate>
+  </button>
+
+  <button type="button"
+          class="btn btn-primary"
+          ng-disabled="schemaForm.$invalid"
+          ng-click="ctrl.submit($event)">
+    <span class="fa fa-chevron-right"></span>
+    {$::ctrl.submitText$}
+  </button>
+</div>

--- a/esi_ui/static/dashboard/project/esi/nodes/esi-nodes-table.controller.js
+++ b/esi_ui/static/dashboard/project/esi/nodes/esi-nodes-table.controller.js
@@ -7,12 +7,15 @@
 
   controller.$inject = [
     '$q',
+    '$timeout',
     'horizon.dashboard.project.esi.esiNodesTableService',
     'horizon.dashboard.project.esi.nodeConfig',
     'horizon.dashboard.project.esi.nodeFilterFacets',
     'horizon.framework.widgets.toast.service',
     'horizon.framework.widgets.modal-wait-spinner.service',
   ];
+
+  const REFRESH_RATE = 10000;
 
   var POWER_ON_TRANSITIONS = [
     {
@@ -31,7 +34,25 @@
     }
   ];
 
-  function controller($q, nodesService, config, filterFacets, toastService, spinnerService) {
+  const PROVISION_ERROR_STATES = new Set([
+    'error',
+    'deploy failed',
+    'clean failed',
+    'service failed',
+    'inspect failed',
+    'adopt failed',
+    'rescue failed',
+    'unrescue failed'
+  ]);
+
+  const PROVISION_STABLE_STATES = new Set([
+    'manageable',
+    'available',
+    'active',
+    'rescue'
+  ]);
+
+  function controller($q, $timeout, nodesService, config, filterFacets, toastService, spinnerService) {
     var ctrl = this;
 
     ctrl.config = config;
@@ -42,6 +63,8 @@
     ctrl.getPowerTransitions = getPowerTransitions;
     ctrl.setPowerState = setPowerState;
     ctrl.deleteLease = deleteLease;
+    ctrl.provision = provision;
+    ctrl.unprovision = unprovision;
 
     ////////////////
 
@@ -54,6 +77,22 @@
         ctrl.nodesSrc = response.data.nodes;
         ctrl.nodesDisplay = ctrl.nodesSrc;
         console.log(ctrl.nodesSrc);
+
+        var in_provision_transition = false;
+        ctrl.nodesSrc.forEach(function(node) {
+          if (PROVISION_ERROR_STATES.has(node.provision_state)) {
+            return;
+          }
+
+          if (PROVISION_STABLE_STATES.has(node.target_provision_state)) {
+            in_provision_transition = true;
+          }
+        });
+
+        if (in_provision_transition) {
+          $timeout(init, REFRESH_RATE);
+        }
+
         spinnerService.hideModalSpinner();
       })
       .catch(function(response) {
@@ -108,6 +147,49 @@
         toastService.add('error', 'Unable to cancel lease. ' + (response.data ? response.data : ''));
         spinnerService.hideModalSpinner();
       });
+    }
+
+    function provision(nodes) {
+      if (nodes.length === 0) {
+        toastService.add('error', 'No nodes were selected to provision.');
+        return;
+      }
+
+      nodesService.editProvision()
+      .then(function(provision_params) {
+        angular.forEach(nodes, function(node) {
+          node.target_provision_state = 'active';
+          nodesService.provision(node, provision_params)
+          .then(function() {
+            toastService.add('success', 'Provisioning request sent.');
+          })
+          .catch(function(response) {
+            toastService.add('error', 'Unable to provision a node. ' + (response.data ? response.data : ''));
+          });
+        });
+
+        $timeout(init, 60000);
+      });
+    }
+
+    function unprovision(nodes) {
+      if (nodes.length === 0) {
+        toastService.add('error', 'No nodes were selected to unprovision.');
+        return;
+      }
+
+      angular.forEach(nodes, function(node) {
+        node.target_provision_state = 'available';
+        nodesService.unprovision(node)
+        .then(function() {
+          toastService.add('success', 'Unprovisioning request sent.');
+        })
+        .catch(function(response) {
+          toastService.add('error', 'Unable to unprovision a node. ' + (response.data ? response.data : ''));
+        });
+      });
+
+      $timeout(init, 60000);
     }
   }
 

--- a/esi_ui/static/dashboard/project/esi/nodes/esi-nodes-table.html
+++ b/esi_ui/static/dashboard/project/esi/nodes/esi-nodes-table.html
@@ -20,6 +20,26 @@
             {$ ::'Delete Leases' | translate $}
           </button>
         </action-list>
+        <action-list>
+          <button class="btn btn-default"
+                  ng-class="actionClasses"
+                  ng-disabled="tCtrl.selected.length === 0"
+                  ng-click="ctrl.provision(tCtrl.selected);
+                            $event.stopPropagation();">
+            <span class="fa fa-pencil"></span>
+            {$ ::'Provision Nodes' | translate $}
+          </button>
+        </action-list>
+        <action-list>
+          <button class="btn btn-danger"
+                  ng-class="actionClasses"
+                  ng-disabled="tCtrl.selected.length === 0"
+                  ng-click="ctrl.unprovision(tCtrl.selected);
+                            $event.stopPropagation();">
+            <span class="fa fa-times"></span>
+            {$ ::'Unprovision Nodes' | translate $}
+          </button>
+        </action-list>
       </div>
     </div>
 
@@ -109,6 +129,29 @@
                                $event.preventDefault()">
                     <span class="fa fa-trash"></span>
                     {$ ::'Delete Lease' | translate $}
+                  </a>
+                </li>
+                <li role="presentation"
+                    ng-if="node.status === 'active' && node.target_provision_state === null && node.provision_state === 'available'">
+                  <a role="menuitem"
+                     ng-click="ctrl.provision([node]);
+                               $event.stopPropagation();
+                               $event.preventDefault()">
+                    <span class="fa fa-pencil"></span>
+                    {$ ::'Provision' | translate $}
+                  </a>
+                </li>
+                <li role="presentation"
+                    ng-if="node.status === 'active'
+                           && node.target_provision_state === null
+                           && (node.provision_state === 'active' || node.provision_state === 'deploy failed')">
+                  <a class="text-danger"
+                     role="menuitem"
+                     ng-click="ctrl.unprovision([node]);
+                               $event.stopPropagation();
+                               $event.preventDefault()">
+                    <span class="fa fa-times"></span>
+                    {$ ::'Unprovision' | translate $}
                   </a>
                 </li>
                 <li role="presentation"

--- a/esi_ui/static/dashboard/project/esi/nodes/esi-nodes-table.service.js
+++ b/esi_ui/static/dashboard/project/esi/nodes/esi-nodes-table.service.js
@@ -6,14 +6,19 @@
     .factory('horizon.dashboard.project.esi.esiNodesTableService', nodesService);
     
   nodesService.$inject = [
+    '$uibModal',
     'horizon.framework.util.http.service',
+    'horizon.dashboard.project.esi.basePath',
   ];
   
-  function nodesService(apiService) {
+  function nodesService($uibModal, apiService, basePath) {
     var service = {
       nodeList: nodeList,
       setPowerState: setPowerState,
       deleteLease: deleteLease,
+      editProvision: editProvision,
+      provision: provision,
+      unprovision: unprovision
     };
     return service;
 
@@ -31,6 +36,25 @@
 
     function deleteLease(lease_uuid) {
       return apiService.delete('/api/esi/lease/' + lease_uuid);
+    }
+
+    function editProvision() {
+      var modalConfig = {
+        backdrop: 'static',
+        keyboard: false,
+        controller: 'horizon.dashboard.project.esi.ProvisionModalFormController as ctrl',
+        templateUrl: basePath + 'forms/provision-modal-form.html'
+      };
+
+      return $uibModal.open(modalConfig).result;
+    }
+
+    function provision(node, provision_params) {
+      return apiService.put('/api/esi/nodes/' + node.uuid + '/deploy/', provision_params);
+    }
+
+    function unprovision(node) {
+      return apiService.put('/api/esi/nodes/' + node.uuid + '/undeploy/');
     }
   }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 esisdk>=0.4.0 # Apache-2.0
-horizon
+horizon>=24.0.0
+metalsmith>=2.3.0


### PR DESCRIPTION
On the nodes panel, under the actions button, the
user can click the 'Provision' button to view a
config menu where to set the image, networks, ssh
keys, hostname, root size (GB), and swap space (MB). 
The view will update every 30s until all selected
nodes for provisioning either error out or become active.