### PR TITLE
Add Node Networking Configuration

### DIFF
--- a/esi_ui/api/esi_api.py
+++ b/esi_ui/api/esi_api.py
@@ -129,6 +129,19 @@ def set_power_state(request, node, target):
     return esiclient(token=token).baremetal.wait_for_node_power_state(node=node, expected_state=target)
 
 
+def network_attach(request, node):
+    connection = esiclient(token=request.user.token.id)
+    attach_info = json.loads(request.body.decode('utf-8'))
+
+    return nodes.network_attach(connection, node, attach_info)
+
+
+def network_detach(request, node, vif):
+    connection = esiclient(token=request.user.token.id)
+
+    return nodes.network_detach(connection, node, port=vif)
+
+
 def offer_list(request):
     token = request.user.token.id
 

--- a/esi_ui/api/esi_rest_api.py
+++ b/esi_ui/api/esi_rest_api.py
@@ -55,6 +55,34 @@ class StatesPower(generic.View):
 
 
 @urls.register
+class VifsAttach(generic.View):
+
+    url_regex = r'esi/nodes/(?P<node>{})/vifs$'.format(LOGICAL_NAME_PATTERN)
+
+    @rest_utils.ajax(data_required=True)
+    def post(self, request, node):
+        info = esi_api.network_attach(request, node)
+        return {
+            'node': info['node'].id,
+            'ports': [port.name for port in info['ports']],
+            'networks': [network.name for network in info['networks']]
+        }
+
+
+@urls.register
+class VifsDetach(generic.View):
+
+    url_regex = r'esi/nodes/(?P<node>{})/vifs/(?P<port>{})$'.format(LOGICAL_NAME_PATTERN, LOGICAL_NAME_PATTERN)
+
+    @rest_utils.ajax()
+    def delete(self, request, node, port):
+        is_detached = esi_api.network_detach(request, node, port)
+        return {
+            'is_detached': is_detached
+        }
+
+
+@urls.register
 class Offers(generic.View):
 
     url_regex = r'esi/offers/$'

--- a/esi_ui/static/dashboard/project/esi/esi.module.js
+++ b/esi_ui/static/dashboard/project/esi/esi.module.js
@@ -2,7 +2,7 @@
   'use strict';
 
   angular
-    .module('horizon.dashboard.project.esi', [])
+    .module('horizon.dashboard.project.esi', ['horizon.dashboard.project.esi.nodes.manage-networks'])
     .config(config);
 
   config.$inject = ['$provide', '$windowProvider'];

--- a/esi_ui/static/dashboard/project/esi/nodes/esi-nodes-table.controller.js
+++ b/esi_ui/static/dashboard/project/esi/nodes/esi-nodes-table.controller.js
@@ -11,6 +11,7 @@
     'horizon.dashboard.project.esi.esiNodesTableService',
     'horizon.dashboard.project.esi.nodeConfig',
     'horizon.dashboard.project.esi.nodeFilterFacets',
+    'horizon.dashboard.project.esi.nodes.manage-networks.modal.service',
     'horizon.framework.widgets.toast.service',
     'horizon.framework.widgets.modal-wait-spinner.service',
   ];
@@ -52,7 +53,7 @@
     'rescue'
   ]);
 
-  function controller($q, $timeout, nodesService, config, filterFacets, toastService, spinnerService) {
+  function controller($q, $timeout, nodesService, config, filterFacets, manageNetworksModalService, toastService, spinnerService) {
     var ctrl = this;
 
     ctrl.config = config;
@@ -65,6 +66,7 @@
     ctrl.deleteLease = deleteLease;
     ctrl.provision = provision;
     ctrl.unprovision = unprovision;
+    ctrl.manageNodeNetworks = manageNodeNetworks;
 
     ////////////////
 
@@ -190,6 +192,27 @@
       });
 
       $timeout(init, 60000);
+    }
+
+    function manageNodeNetworks(node) {
+      var launchContext = {
+        node: node
+      };
+
+      manageNetworksModalService.open(launchContext)
+      .then(function (response) {
+        if (response.action === 'attach') {
+          nodesService.networkAttach(node, response.attach)
+          .then(function() {
+            init();
+          });
+        } else {
+          nodesService.networkDetach(node, response.detach)
+          .then(function() {
+            init();
+          });
+        }
+      });
     }
   }
 

--- a/esi_ui/static/dashboard/project/esi/nodes/esi-nodes-table.html
+++ b/esi_ui/static/dashboard/project/esi/nodes/esi-nodes-table.html
@@ -131,6 +131,16 @@
                     {$ ::'Delete Lease' | translate $}
                   </a>
                 </li>
+                <li role="presentation">
+                  <a role="menuitem"
+                     ng-if="node.status === 'active'"
+                     ng-click="ctrl.manageNodeNetworks(node);
+                               $event.stopPropagation();
+                               $event.preventDefault()">
+                    <span class="fa fa-pencil"></span>
+                    {$ ::'Manage Networks' | translate $}
+                  </a>
+                </li>
                 <li role="presentation"
                     ng-if="node.status === 'active' && node.target_provision_state === null && node.provision_state === 'available'">
                   <a role="menuitem"

--- a/esi_ui/static/dashboard/project/esi/nodes/esi-nodes-table.service.js
+++ b/esi_ui/static/dashboard/project/esi/nodes/esi-nodes-table.service.js
@@ -18,7 +18,10 @@
       deleteLease: deleteLease,
       editProvision: editProvision,
       provision: provision,
-      unprovision: unprovision
+      unprovision: unprovision,
+      editNetworks: editNetworks,
+      networkAttach: networkAttach,
+      networkDetach: networkDetach,
     };
     return service;
 
@@ -55,6 +58,25 @@
 
     function unprovision(node) {
       return apiService.put('/api/esi/nodes/' + node.uuid + '/undeploy/');
+    }    
+
+    function editNetworks() {
+      var modalConfig = {
+        backdrop: 'static',
+        keyboard: false,
+        controller: 'horizon.dashboard.project.esi.NetworkModalFormController as ctrl',
+        templateUrl: basePath + 'forms/network-modal-form.html'
+      };
+
+      return $uibModal.open(modalConfig).result;
+    }
+
+    function networkAttach(node, network_params) {
+      return apiService.post('/api/esi/nodes/' + node.uuid + '/vifs', network_params);
+    }
+
+    function networkDetach(node, network_params) {
+      return apiService.delete('/api/esi/nodes/' + node.uuid + '/vifs/' + network_params.port);
     }
   }
 

--- a/esi_ui/static/dashboard/project/esi/nodes/manage-networks/attach/attach.html
+++ b/esi_ui/static/dashboard/project/esi/nodes/manage-networks/attach/attach.html
@@ -1,0 +1,78 @@
+<p class="step-description" translate>Please provide either a network, port, or trunk to attach to the node. A MAC address can optionally be provided.</p>
+
+<div class="form-group">
+  <label class="control-label" translate for="mac_address">MAC Address</label>
+  <div class="alert alert-warning"
+       ng-if="launchContext.node.attachable_mac_addresses.length === 0"
+       translate>There are no available MAC Addresses</div>
+  <select id="mac_address"
+          class="form-control"
+          ng-if="launchContext.node.attachable_mac_addresses.length !== 0"
+          ng-options="mac_address for mac_address in launchContext.node.attachable_mac_addresses"
+          ng-model="stepModels.attach.mac_address">
+      <option value="">Any</option>
+  </select>
+</div>
+
+<div class="form-group">
+  <label class="control-label" translate for="network_name">Network</label>
+  <div class="horizon-loading-bar" ng-if="!model.loaded.networks">
+    <div class="progress progress-striped active">
+      <div class="progress-bar"></div>
+    </div>
+  </div>
+  <div class="alert alert-warning"
+      ng-if="model.loaded.networks && model.networks.length === 0"
+      translate>There are no networks</div>
+  <select id="network_name"
+          class="form-control"
+          ng-required="currentIndex === 0 && !stepModels.attach.port && !stepModels.attach.trunk"
+          ng-disabled="!launchContext.node.attachable_mac_addresses.length || stepModels.attach.port || stepModels.attach.trunk"
+          ng-if="model.loaded.networks && model.networks.length !== 0"
+          ng-options="network.id as network.name for network in model.networks"
+          ng-model="stepModels.attach.network">
+    <option value=""></option>
+  </select>
+</div>
+
+<div class="form-group">
+  <label class="control-label" translate for="port_name">Port</label>
+  <div class="horizon-loading-bar" ng-if="!model.loaded.ports">
+    <div class="progress progress-striped active">
+      <div class="progress-bar"></div>
+    </div>
+  </div>
+  <div class="alert alert-warning"
+       ng-if="model.loaded.ports && model.ports.length === 0"
+       translate>There are no ports</div>
+  <select id="port_name"
+          class="form-control"
+          ng-required="currentIndex === 0 && !stepModels.attach.network && !stepModels.attach.trunk"
+          ng-disabled="!launchContext.node.attachable_mac_addresses.length || stepModels.attach.network || stepModels.attach.trunk"
+          ng-if="model.loaded.ports && model.ports.length !== 0"
+          ng-options="port.id as port.name for port in model.ports"
+          ng-model="stepModels.attach.port">
+    <option value=""></option>
+  </select>
+</div>
+
+<div class="form-group">
+  <label class="control-label" translate for="trunk_name">Trunk</label>
+  <div class="horizon-loading-bar" ng-if="!model.loaded.trunks">
+    <div class="progress progress-striped active">
+      <div class="progress-bar"></div>
+    </div>
+  </div>
+  <div class="alert alert-warning"
+       ng-if="model.loaded.trunks && model.trunks.length === 0"
+       translate>There are no trunks</div>
+  <select id="trunk_name"
+          class="form-control"
+          ng-required="currentIndex === 0 && !stepModels.attach.network && !stepModels.attach.port"
+          ng-disabled="!launchContext.node.attachable_mac_addresses.length || stepModels.attach.network || stepModels.attach.port"
+          ng-if="model.loaded.trunks && model.trunks.length !== 0"
+          ng-options="trunk.id as trunk.name for trunk in model.trunks"
+          ng-model="stepModels.attach.trunk">
+    <option value=""></option>
+  </select>
+</div>

--- a/esi_ui/static/dashboard/project/esi/nodes/manage-networks/detach/detach.html
+++ b/esi_ui/static/dashboard/project/esi/nodes/manage-networks/detach/detach.html
@@ -1,0 +1,16 @@
+<p class="step-description" translate>Please specify which network port you want to detach this node from.</p>
+
+<div class="form-group">
+  <label class="control-label" translate for="port_name">Port</label>
+  <div class="alert alert-warning"
+       ng-if="launchContext.node.detachable_ports.length === 0"
+       translate>There are no detachable ports</div>
+  <select id="port_name"
+          class="form-control"
+          ng-required="currentIndex === 1"
+          ng-if="launchContext.node.detachable_ports.length !== 0"
+          ng-options="port for port in launchContext.node.detachable_ports"
+          ng-model="stepModels.detach.port">
+    <option value=""></option>
+  </select>
+</div>

--- a/esi_ui/static/dashboard/project/esi/nodes/manage-networks/manage-networks-modal.service.js
+++ b/esi_ui/static/dashboard/project/esi/nodes/manage-networks/manage-networks-modal.service.js
@@ -1,0 +1,45 @@
+(function () {
+  'use strict';
+
+  angular
+    .module('horizon.dashboard.project.esi.nodes.manage-networks')
+    .factory(
+      'horizon.dashboard.project.esi.nodes.manage-networks.modal.service',
+      ManageNetworksModalService
+    );
+
+  ManageNetworksModalService.$inject = [
+    '$uibModal',
+    'horizon.dashboard.project.esi.nodes.manage-networks.modal-spec'
+  ];
+
+  function ManageNetworksModalService($uibModal, modalSpec) {
+    var service = {
+      open: open
+    };
+
+    return service;
+
+    function open(launchContext) {
+      var localSpec = {
+        resolve: {
+          launchContext: function () {
+            launchContext.node.attachable_mac_addresses = launchContext.node.mac_addresses.filter(function(mac_address, index) {
+              return !launchContext.node.network_names[index];
+            });
+            launchContext.node.detachable_ports = launchContext.node.network_port_names.filter(function(port_name) {
+              return port_name;
+            });
+
+            return launchContext;
+          }
+        }
+      };
+
+      angular.extend(localSpec, modalSpec);
+
+      return $uibModal.open(localSpec).result;
+    }
+  }
+
+})();

--- a/esi_ui/static/dashboard/project/esi/nodes/manage-networks/manage-networks-model.service.js
+++ b/esi_ui/static/dashboard/project/esi/nodes/manage-networks/manage-networks-model.service.js
@@ -1,0 +1,68 @@
+(function () {
+  'use strict';
+
+  var noop = angular.noop;
+
+  angular
+    .module('horizon.dashboard.project.esi.nodes.manage-networks')
+    .factory('manageNetworksModel', manageNetworksModel);
+
+  manageNetworksModel.$inject = [
+    'horizon.app.core.openstack-service-api.neutron',
+  ];
+
+  function manageNetworksModel(neutronAPI) {
+    var model = {
+      loaded: {
+        networks: false,
+        ports: false,
+        trunks: false
+      },
+
+      networks: [],
+      ports: [],
+      trunks: [],
+
+      disabled: {
+        networks: false,
+        ports: false,
+        trunks: false
+      },
+      
+      initialize: initialize,
+      submit: submit
+    };
+
+    return model;
+
+    ////////////////
+
+    function initialize() {
+      neutronAPI.getNetworks().then(onGetNetworks, noop);
+      neutronAPI.getPorts().then(onGetPorts, noop);
+      neutronAPI.getTrunks().then(onGetTrunks, noop);
+    }
+
+    function submit(stepModels) {
+      return Promise.resolve(stepModels);
+    }
+
+    function onGetNetworks(response) {
+      model.networks = response.data.items;
+      model.loaded.networks = true;
+    }
+
+    function onGetPorts(response) {
+      model.ports = response.data.items.filter(function (port) {
+        return port.name;
+      });
+      model.loaded.ports = true;
+    }
+
+    function onGetTrunks(response) {
+      model.trunks = response.data.items;
+      model.loaded.trunks = true;
+    }
+  }
+
+})();

--- a/esi_ui/static/dashboard/project/esi/nodes/manage-networks/manage-networks-wizard.controller.js
+++ b/esi_ui/static/dashboard/project/esi/nodes/manage-networks/manage-networks-wizard.controller.js
@@ -1,0 +1,27 @@
+(function () {
+  'use strict';
+
+  angular
+    .module('horizon.dashboard.project.esi.nodes.manage-networks')
+    .controller('ManageNetworksWizardController', ManageNetworksWizardController);
+
+  ManageNetworksWizardController.$inject = [
+    '$scope',
+    'manageNetworksModel',
+    'horizon.dashboard.project.esi.nodes.manage-networks.workflow',
+    'horizon.framework.widgets.wizard.events'
+  ];
+
+  function ManageNetworksWizardController($scope, manageNetworksModel, manageNetworksWorkflow, wizardEvents) {
+    $scope.workflow = manageNetworksWorkflow;
+    $scope.model = manageNetworksModel;
+    $scope.submit = $scope.model.submit;
+
+    $scope.model.initialize();
+
+    $scope.$on(wizardEvents.BEFORE_SUBMIT, function() {
+      $scope.stepModels.action = ($scope.currentIndex ? 'detach' : 'attach');
+    });
+  }
+
+})();

--- a/esi_ui/static/dashboard/project/esi/nodes/manage-networks/manage-networks-workflow.service.js
+++ b/esi_ui/static/dashboard/project/esi/nodes/manage-networks/manage-networks-workflow.service.js
@@ -1,0 +1,42 @@
+(function () {
+  'use strict';
+
+  angular
+    .module('horizon.dashboard.project.esi.nodes.manage-networks')
+    .factory('horizon.dashboard.project.esi.nodes.manage-networks.workflow', manageNetworksWorkflow);
+
+  manageNetworksWorkflow.$inject = [
+    'horizon.dashboard.project.esi.nodes.manage-networks.basePath',
+    'horizon.app.core.workflow.factory'
+  ];
+
+  function manageNetworksWorkflow(basePath, dashboardWorkflow) {
+    return dashboardWorkflow({
+      title: gettext('Manage Networks'),
+
+      steps: [
+        {
+          id: 'attach',
+          title: gettext('Attach'),
+          templateUrl: basePath + 'attach/attach.html',
+          formName: 'attachNetworkForm'
+        },
+        {
+          id: 'detach',
+          title: gettext('Detach'),
+          templateUrl: basePath + 'detach/detach.html',
+          formName: 'detachNetworkForm'
+        },
+      ],
+
+      btnText: {
+        finish: gettext('Submit')
+      },
+
+      btnIcon: {
+        finish: 'fa-cloud-upload'
+      }
+    });
+  }
+
+})();

--- a/esi_ui/static/dashboard/project/esi/nodes/manage-networks/manage-networks.module.js
+++ b/esi_ui/static/dashboard/project/esi/nodes/manage-networks/manage-networks.module.js
@@ -1,0 +1,24 @@
+(function () {
+  'use strict';
+
+  angular
+    .module('horizon.dashboard.project.esi.nodes.manage-networks', [])
+    .config(config)
+    .constant('horizon.dashboard.project.esi.nodes.manage-networks.modal-spec', {
+      backdrop: 'static',
+      size: 'lg',
+      controller: 'ModalContainerController',
+      template: '<wizard class="wizard" ng-controller="ManageNetworksWizardController"></wizard>'
+    });
+  
+  config.$inject = [
+    '$provide',
+    '$windowProvider'
+  ];
+
+  function config($provide, $windowProvider) {
+    var basePath = $windowProvider.$get().STATIC_URL + 'dashboard/project/esi/nodes/manage-networks/';
+    $provide.constant('horizon.dashboard.project.esi.nodes.manage-networks.basePath', basePath);
+  }
+
+})();

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-esisdk>=0.4.0 # Apache-2.0
+esisdk>=0.5.0 # Apache-2.0
 horizon>=24.0.0
 metalsmith>=2.3.0


### PR DESCRIPTION
After pressing the 'Actions' button, the user will be shown a config wizard to either attach a network/port/trunk (to a specified MAC address) or detach a port. After the request is submitted, the node's network info will automatically refresh when the request is successful.