### PR TITLE
Add Baremetal Topology Panel

### DIFF
--- a/esi_ui/content/baremetal_topology/panel.py
+++ b/esi_ui/content/baremetal_topology/panel.py
@@ -1,0 +1,7 @@
+from django.utils.translation import gettext_lazy as _
+import horizon
+
+
+class BaremetalTopology(horizon.Panel):
+    name = _("Baremetal Topology")
+    slug = "baremetal_topology"

--- a/esi_ui/content/baremetal_topology/templates/baremetal_topology/_graph_view.html
+++ b/esi_ui/content/baremetal_topology/templates/baremetal_topology/_graph_view.html
@@ -1,0 +1,28 @@
+{% load i18n %}
+
+<div class="description">
+  {% blocktrans trimmed %}
+    Resize the canvas by scrolling up/down with your mouse/trackpad on the topology.
+    Pan around the canvas by clicking and dragging the space behind the topology.
+  {% endblocktrans %}
+</div>
+<div class="topology-navi">
+  <div class="btn-group" data-toggle="buttons">
+    <label class="btn btn-default" id="toggle_labels_label">
+      <input type="checkbox" autocomplete="off" id="toggle_labels">
+      <span class="fa fa-th-large"></span> {% trans "Toggle Labels" %}
+    </label>
+    <label class="btn btn-default" id="toggle_networks_label" style="display: none">
+      <input type="checkbox" autocomplete="off" id="toggle_networks">
+      <span class="fa fa-th"></span>  {% trans "Toggle Network Collapse" %}
+    </label>
+  </div>
+    <button type="button" class="btn btn-default" id="center_topology">
+      <span class="fa fa-refresh"></span> {%trans "Center Topology" %}
+    </button>
+</div>
+<div id="topologyCanvasContainer" class="d3-container">
+  <div class="nodata">{% blocktrans trimmed %}
+    There are no networks, routers, or baremetal nodes to display.
+    {% endblocktrans %}</div>
+</div>

--- a/esi_ui/content/baremetal_topology/templates/baremetal_topology/_post_massage.html
+++ b/esi_ui/content/baremetal_topology/templates/baremetal_topology/_post_massage.html
@@ -1,0 +1,27 @@
+<script type="text/javascript">
+(function(){
+  $(window).on('message',function(e){
+    var message = JSON.parse(e.originalEvent.data);
+    var id = message.id;
+    $('button[id*="' + id + '"]').click();
+  });
+
+  $('.messages .alert').each(function(){
+    var $this = $(this);
+    var message = {};
+    message.action = "alert";
+    message.iframe_id = $(window.frameElement).attr('id');
+    message.type =
+      ($this.hasClass('alert-info')) ?    'info' :
+      ($this.hasClass('alert-warning')) ? 'warning' :
+      ($this.hasClass('alert-success')) ? 'success' :
+      ($this.hasClass('alert-danger')) ?   'error' :
+      null;
+    message.message = $this.children('p')
+      .html()
+      .replace(/<strong>(.*?)<\/strong>/g,'');
+    var target = (parent.postMessage ? parent : (parent.document.postMessage ? parent.document : undefined));
+    target.postMessage(JSON.stringify(message, null, 2), '*');
+  });
+})();
+</script>

--- a/esi_ui/content/baremetal_topology/templates/baremetal_topology/_svg_element.html
+++ b/esi_ui/content/baremetal_topology/templates/baremetal_topology/_svg_element.html
@@ -1,0 +1,120 @@
+{% load i18n %}
+
+<svg width="400" height="400" id="topology_canvas">
+  <defs>
+    <pattern id="device_normal_bg" patternUnits="userSpaceOnUse" x="0" y="0" width="20" height="20">
+      <g>
+        <rect width="20" height="20" class="base_bg_normal"></rect>
+      </g>
+    </pattern>
+    <pattern id="device_normal_bg_loading" patternUnits="userSpaceOnUse" x="0" y="0" width="20" height="20">
+      <g>
+        <rect width="20" height="20" class="loading_bg_normal"></rect>
+        <path d="M0 20L20 0ZM22 18L18 22ZM-2 2L2 -2Z" stroke-linecap="square" stroke="rgba(0, 0, 0, 0.3)" stroke-width="7"></path>
+      </g>
+      <animate attributeName="x" attributeType="XML" begin="0s" dur="0.5s" from="0" to="-20" repeatCount="indefinite"></animate>
+    </pattern>
+    <pattern id="device_small_bg" patternUnits="userSpaceOnUse" x="0" y="0" width="20" height="20">
+      <g>
+        <rect width="20" height="20" class="base_bg_small"></rect>
+      </g>
+    </pattern>
+    <pattern id="device_small_bg_loading" patternUnits="userSpaceOnUse" x="0" y="0" width="5" height="5">
+      <g>
+        <rect width="5" height="5" class="loading_bg_small"></rect>
+        <path d="M0 5L5 0ZM6 4L4 6ZM-1 1L1 -1Z" stroke-linecap="square" stroke="rgba(0, 0, 0, 0.4)" stroke-width="1.5"></path>
+      </g>
+      <animate attributeName="x" attributeType="XML" begin="0s" dur="0.5s" from="0" to="-5" repeatCount="indefinite"></animate>
+    </pattern>
+  </defs>
+</svg>
+<svg id="topology_template" display="none">
+  <g class="router_small device_body">
+    <g class="ports" pointer-events="none"></g>
+    <rect rx="3" ry="3" width="20" height="20" class="frame"></rect>
+    <g transform="translate(3.5,3)" class="icon">
+      <polygon points="12.51,4.23 12.51,0.49 8.77,0.49 9.68,1.4 6.92,4.16 8.84,6.08 11.6,3.32  "></polygon>
+      <polygon points="0.49,8.77 0.49,12.51 4.23,12.51 3.32,11.6 6.08,8.83 4.17,6.92 1.4,9.68  "></polygon>
+      <polygon points="1.85,5.59 5.59,5.59 5.59,1.85 4.68,2.76 1.92,0 0,1.92 2.76,4.68   "></polygon>
+      <polygon points="11.15,7.41 7.41,7.41 7.41,11.15 8.32,10.24 11.08,13 13,11.08 10.24,8.32   "></polygon>
+    </g>
+  </g>
+  <g class="instance_small device_body">
+    <g class="ports" pointer-events="none"></g>
+    <rect rx="3" ry="3" width="20" height="20" class="frame"></rect>
+    <g transform="translate(5,3)" class="icon">
+      <rect class="instance_bg" width="10" height="13"></rect>
+      <rect x="2" y="1" fill="#FFFFFF" width="6" height="2"></rect>
+      <rect x="2" y="4" fill="#FFFFFF" width="6" height="2"></rect>
+      <circle class="active" cx="3" cy="10" r="1.3"></circle>
+    </g>
+  </g>
+  <g class="network_container_small">
+    <rect rx="7" ry="7" width="15" height="200" style="fill: #8541B5;" class="network-rect"></rect>
+    <text x="250" y="-3" class="network-name" transform="rotate(90 0 0)" pointer-events="none">Network</text>
+    <text x="0" y="-20" class="network-cidr" transform="rotate(90 0 0)">0.0.0.0</text>
+    <text x="0" y="-20" class="network-type" transform="rotate(90 0 0)"
+          data-toggle="tooltip" data-placement="bottom" title="{% trans 'External Network' %}"></text>
+  </g>
+  <g class="router_normal device_body">
+    <g class="ports" pointer-events="none"></g>
+    <rect class="frame" x="0" y="0" rx="6" ry="6" width="90" height="50"></rect>
+    <g class="texts" pointer-events="none">
+      <rect class="texts_bg" x="1.5" y="32" width="87" height="17"></rect>
+      <text x="45" y="46" class="type">{% trans "Router" %}</text>
+      <text x="45" y="22" class="name">router</text>
+    </g>
+    <g class="icon" transform="translate(6,6)" pointer-events="none">
+      <circle class="icon_bg" cx="0" cy="0" r="12"></circle>
+      <g transform="translate(-6.5,-6.5)">
+        <polygon points="12.51,4.23 12.51,0.49 8.77,0.49 9.68,1.4 6.92,4.16 8.84,6.08 11.6,3.32  "></polygon>
+        <polygon points="0.49,8.77 0.49,12.51 4.23,12.51 3.32,11.6 6.08,8.83 4.17,6.92 1.4,9.68  "></polygon>
+        <polygon points="1.85,5.59 5.59,5.59 5.59,1.85 4.68,2.76 1.92,0 0,1.92 2.76,4.68   "></polygon>
+        <polygon points="11.15,7.41 7.41,7.41 7.41,11.15 8.32,10.24 11.08,13 13,11.08 10.24,8.32  "></polygon>
+      </g>
+    </g>
+  </g>
+  <g class="instance_normal device_body">
+    <g class="ports" pointer-events="none"></g>
+    <rect class="frame" x="0" y="0" rx="6" ry="6" width="90" height="50"></rect>
+    <g class="texts">
+      <rect class="texts_bg" x="1.5" y="32" width="87" height="17"></rect>
+      <text x="45" y="46" class="type">{% trans "Instance" %}</text>
+      <text x="45" y="22" class="name">instance</text>
+    </g>
+    <g class="icon" transform="translate(6,6)">
+      <circle class="icon_bg" cx="0" cy="0" r="12"></circle>
+      <g transform="translate(-5,-6.5)">
+        <rect class="instance_bg" width="10" height="13"></rect>
+        <rect x="2" y="1" fill="#FFFFFF" width="6" height="2"></rect>
+        <rect x="2" y="4" fill="#FFFFFF" width="6" height="2"></rect>
+        <circle class="active" cx="3" cy="10" r="1.3"></circle>
+      </g>
+    </g>
+  </g>
+  <g class="port_normal device_body">
+    <g class="ports" pointer-events="none"></g>
+    <rect class="frame" x="0" y="0" rx="6" ry="6" width="90" height="50"></rect>
+    <g class="texts">
+      <rect class="texts_bg" x="1.5" y="32" width="87" height="17"></rect>
+      <text x="45" y="46" class="type">{% trans "Network Ports" %}</text>
+      <text x="45" y="22" class="name">port</text>
+    </g>
+    <g class="icon" transform="translate(6,6)">
+      <circle class="icon_bg" cx="0" cy="0" r="12"></circle>
+      <g transform="translate(-5,-6.5)">
+        <rect class="instance_bg" width="10" height="13"></rect>
+        <rect x="2" y="1" fill="#FFFFFF" width="6" height="2"></rect>
+        <rect x="2" y="4" fill="#FFFFFF" width="6" height="2"></rect>
+        <circle class="active" cx="3" cy="10" r="1.3"></circle>
+      </g>
+    </g>
+  </g>
+  <g class="network_container_normal">
+    <rect rx="9" ry="9" width="17" height="500" style="fill: #8541B5;" class="network-rect"></rect>
+    <text x="250" y="-4" class="network-name" transform="rotate(90 0 0)" pointer-events="none">Network</text>
+    <text x="490" y="-20" class="network-cidr" transform="rotate(90 0 0)">0.0.0.0</text>
+    <text x="490" y="-20" class="network-type" transform="rotate(90 0 0)"
+          data-toggle="tooltip" data-placement="bottom" title="{% trans 'External Network' %}"></text>
+  </g>
+</svg>

--- a/esi_ui/content/baremetal_topology/templates/baremetal_topology/client_side/_balloon_container.html
+++ b/esi_ui/content/baremetal_topology/templates/baremetal_topology/client_side/_balloon_container.html
@@ -1,0 +1,16 @@
+{% extends "horizon/client_side/template.html" %}
+{% load horizon i18n %}
+
+{% block id %}balloon_container{% endblock %}
+
+{% block template %}
+{% jstemplate %}
+<div class="topologyBalloon" id="[[balloon_id]]">
+  <a href="#close" class="closeTopologyBalloon">&times;</a>
+  <div class="contentBody">
+    [[> table1]]
+    [[> table2]]
+  </div>
+</div>
+{% endjstemplate %}
+{% endblock %}

--- a/esi_ui/content/baremetal_topology/templates/baremetal_topology/client_side/_balloon_device.html
+++ b/esi_ui/content/baremetal_topology/templates/baremetal_topology/client_side/_balloon_device.html
@@ -1,0 +1,24 @@
+{% extends "horizon/client_side/template.html" %}
+{% load horizon %}
+
+{% block id %}balloon_device{% endblock %}
+
+{% block template %}
+{% jstemplate %}
+<table class="detailInfoTable">
+  <caption data-display="[[name]]">[[name]]</caption>
+  <tbody>
+    <tr>
+      <th class="device">[[id_label]]</th>
+      <td>[[id]]</td>
+    </tr>
+    <tr>
+      <th class="device">[[status_label]]</th>
+      <td>
+        <span class="[[status_class]]">[[status]]</span>
+      </td>
+    </tr>
+  </tbody>
+</table>
+{% endjstemplate %}
+{% endblock %}

--- a/esi_ui/content/baremetal_topology/templates/baremetal_topology/client_side/_balloon_instance.html
+++ b/esi_ui/content/baremetal_topology/templates/baremetal_topology/client_side/_balloon_instance.html
@@ -1,0 +1,23 @@
+{% extends "horizon/client_side/template.html" %}
+{% load horizon %}
+
+{% block id %}balloon_instance{% endblock %}
+
+{% block template %}
+{% jstemplate %}
+<div class="portTableHeader">
+  <div class="title">[[server_connections_label]]</div>
+</div>
+<table class="detailInfoTable">
+  <caption></caption>
+  <tbody>
+    [[#connections]]
+    <tr>
+      <th>[[mac_address]]</th>
+      <td>[[port_name]]</td>
+    </tr>
+    [[/connections]]
+  </tbody>
+</table>
+{% endjstemplate %}
+{% endblock %}

--- a/esi_ui/content/baremetal_topology/templates/baremetal_topology/client_side/_balloon_net.html
+++ b/esi_ui/content/baremetal_topology/templates/baremetal_topology/client_side/_balloon_net.html
@@ -1,0 +1,42 @@
+{% extends "horizon/client_side/template.html" %}
+{% load horizon i18n %}
+
+{% block id %}balloon_net{% endblock %}
+
+{% block template %}
+{% jstemplate %}
+<div class="portTableHeader">
+  <div class="title">[[subnets_label]]</div>
+  <div class="action">
+    <a class="add-subnet btn btn-default btn-xs ajax-modal [[type]]" href="[[add_subnet_url]]">
+      <span class="fa fa-plus"></span>
+      [[add_subnet_label]]
+    </a>
+  </div>
+</div>
+<table class="detailInfoTable">
+  <caption></caption>
+  <tbody>
+    [[#subnet]]
+    <tr>
+      <th>
+        <span data-display="[[id]]" title="[[id]]">
+          <a href="[[url]]">[[id]]</a>
+        </span>
+      </th>
+      <td>[[cidr]]</td>
+      <td class="delete">
+        [[#allow_delete_subnet]]
+        <button class="delete-port btn btn-danger btn-xs"
+          data-router-id="[[router_id]]" data-network-id="[[network_id]]"
+          data-port-id="[[id]]" help_text="{% trans "This action cannot be undone." %}">
+            [[delete_subnet_label]]
+        </button>
+        [[/allow_delete_subnet]]
+      </td>
+    </tr>
+    [[/subnet]]
+  </tbody>
+</table>
+{% endjstemplate %}
+{% endblock %}

--- a/esi_ui/content/baremetal_topology/templates/baremetal_topology/client_side/_balloon_network_port.html
+++ b/esi_ui/content/baremetal_topology/templates/baremetal_topology/client_side/_balloon_network_port.html
@@ -1,0 +1,37 @@
+{% extends "horizon/client_side/template.html" %}
+{% load horizon %}
+
+{% block id %}balloon_network_port{% endblock %}
+
+{% block template %}
+{% jstemplate %}
+<div class="portTableHeader">
+  <div class="title">Network Info</div>
+</div>
+<table class="detailInfoTable">
+  <caption></caption>
+  <tbody>
+    [[#floating_ips]]
+    <tr>
+      <th>Floating IP</th>
+      <td>[[.]]</td>
+    </tr>
+    [[/floating_ips]]
+    [[#fixed_ips]]
+    <tr>
+      <th>Subnet</th>
+      <td>[[subnet_id]]</td>
+      <td>[[ip_address]]</td>
+    </tr>
+    [[/fixed_ips]]
+    [[#sub_ports]]
+    <tr>
+      <th>Subport</th>
+      <td>[[port_id]]</td>
+      <td>[[name]]</td>
+    </tr>
+    [[/sub_ports]]
+  </tbody>
+</table>
+{% endjstemplate %}
+{% endblock %}

--- a/esi_ui/content/baremetal_topology/templates/baremetal_topology/client_side/_balloon_port.html
+++ b/esi_ui/content/baremetal_topology/templates/baremetal_topology/client_side/_balloon_port.html
@@ -1,0 +1,51 @@
+{% extends "horizon/client_side/template.html" %}
+{% load horizon i18n %}
+
+{% block id %}balloon_port{% endblock %}
+
+{% block template %}
+{% jstemplate %}
+<div class="portTableHeader">
+  <div class="title">[[interfaces_label]]</div>
+  <div class="action">
+    <a class="add-interface btn btn-default btn-xs ajax-modal [[type]]" href="[[add_interface_url]]">
+      <span class="fa fa-plus"></span>
+      [[add_interface_label]]
+    </a>
+  </div>
+</div>
+<table class="detailInfoTable">
+  <caption></caption>
+  <tbody>
+    [[#port]]
+    <tr>
+      <th>
+        <span data-display="[[id]]" title="[[id]]">
+          [[#url]]
+            <a href="[[url]]">[[id]]</a>
+          [[/url]]
+          [[^url]]
+            [[id]]
+          [[/url]]
+        </span>
+      </th>
+      <td>[[ip_address]]</td>
+      <td>[[device_owner]]</td>
+      <td>
+        <span class="[[port_status_class]]">[[port_status]]</span>
+      </td>
+      <td class="delete">
+        [[#is_interface]]
+        <button class="delete-port btn btn-danger btn-xs"
+          data-router-id="[[router_id]]" data-network-id="[[network_id]]"
+          data-port-id="[[id]]" help_text="{% trans "This action cannot be undone." %}">
+            [[delete_interface_label]]
+        </button>
+        [[/is_interface]]
+      </td>
+    </tr>
+    [[/port]]
+  </tbody>
+</table>
+{% endjstemplate %}
+{% endblock %}

--- a/esi_ui/content/baremetal_topology/templates/baremetal_topology/iframe.html
+++ b/esi_ui/content/baremetal_topology/templates/baremetal_topology/iframe.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+    <script src="{{ STATIC_URL }}horizon/lib/jquery/jquery.js" type="text/javascript" charset="utf-8"></script>
+  </head>
+  <body>
+    {% include "horizon/_messages.html" %}
+    {% firstof subnets_table.render table.render interfaces_table.render tab_group.render %}
+    {% include "project/baremetal_topology/_post_massage.html" %}
+  </body>
+</html>

--- a/esi_ui/content/baremetal_topology/templates/baremetal_topology/index.html
+++ b/esi_ui/content/baremetal_topology/templates/baremetal_topology/index.html
@@ -1,0 +1,1237 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% trans "Baremetal Topology" %}{% endblock %}
+
+{% block breadcrumb_nav %}
+  <ol class="breadcrumb">
+    <li>{% trans "Project" %}</li>
+    <li>{% trans "ESI" %}</li>
+    <li>{% trans "Baremetal Topology" %}</li>
+  </ol>
+{% endblock %}
+
+{% block page_header %}
+  <hz-page-header
+    header="{$ 'Baremetal Topology' | translate $}">
+  </hz-page-header>
+{% endblock page_header %}
+
+{% block main %}
+
+<noscript>
+{% trans "This panel needs JavaScript support." %}
+</noscript>
+
+{% include "project/baremetal_topology/client_side/_balloon_container.html" %}
+{% include "project/baremetal_topology/client_side/_balloon_device.html" %}
+{% include "project/baremetal_topology/client_side/_balloon_port.html" %}
+{% include "project/baremetal_topology/client_side/_balloon_net.html" %}
+{% include "project/baremetal_topology/client_side/_balloon_instance.html" %}
+{% include "project/baremetal_topology/client_side/_balloon_network_port.html" %}
+
+<div class="row">
+  <div class="col-sm-12">
+    {% include "project/baremetal_topology/_graph_view.html" %}
+    
+    <span data-networktopology="{% url 'horizon:project:baremetal_topology:json' %}" id="networktopology"></span>
+    <div id="topologyMessages"></div>
+
+    <script type="text/javascript">
+      function Network(data) {
+        this.iconType = 'text';
+        this.icon = '\uf0c2'; // Cloud
+        this.collapsed = false;
+        this.type = 'network';
+        this.instances = 0;
+        for (var key in data) {
+          if ({}.hasOwnProperty.call(data, key)) {
+            this[key] = data[key];
+          }
+        }
+      }
+
+      function ExternalNetwork(data) {
+        this.collapsed = false;
+        this.iconType = 'text';
+        this.icon = '\uf0ac'; // Globe
+        this.instances = 0;
+        for (var key in data) {
+          if ({}.hasOwnProperty.call(data, key)) {
+            this[key] = data[key];
+          }
+        }
+      }
+
+      function Router(data) {
+        this.iconType = 'path';
+        this.svg = 'router';
+        this.networks = [];
+        this.ports = [];
+        this.type = 'router';
+        for (var key in data) {
+          if ({}.hasOwnProperty.call(data, key)) {
+            this[key] = data[key];
+          }
+        }
+      }
+
+      function Server(data) {
+        this.iconType = 'text';
+        this.icon = '\uf108'; // Server
+        this.type = 'instance';
+        this.connections = [];
+        for (var key in data) {
+          if ({}.hasOwnProperty.call(data, key)) {
+            this[key] = data[key];
+          }
+        }
+      }
+
+      function Port(data) {
+        this.iconType = 'text';
+        this.icon = '\uf192';
+        this.type = 'port';
+        for (var key in data) {
+          if ({}.hasOwnProperty.call(data, key)) {
+            this[key] = data[key];
+          }
+        }
+      }
+
+      function listContains(obj, list) {
+        // Function to help checking if an object is present on a list
+        for (var i = 0; i < list.length; i++) {
+          if (angular.equals(list[i], obj)) {
+            return true;
+          }
+        }
+        return false;
+      }
+
+      horizon.baremetal_topology = {
+        fa_globe_glyph: '\uf0ac',
+        fa_globe_glyph_width: 15,
+        svg:'#topology_canvas',
+        nodes: [],
+        links: [],
+        data: [],
+        zoom: d3.behavior.zoom(),
+        data_loaded: false,
+        svg_container:'#topologyCanvasContainer',
+        balloonTmpl : null,
+        balloon_deviceTmpl : null,
+        balloon_portTmpl : null,
+        balloon_netTmpl : null,
+        balloon_instanceTmpl : null,
+        balloon_networkPortTmpl : null,
+        network_index: {},
+        balloonID:null,
+        network_height : 0,
+
+        init:function() {
+          var self = this;
+
+          self.$loading_template = horizon.networktopologyloader.setup_loader($(self.svg_container));
+
+          if (angular.element('#networktopology').length === 0) {
+            return;
+          }
+
+          self.data = {};
+          self.data.networks = {};
+          self.data.routers = {};
+          self.data.servers = {};
+          self.data.ports = {};
+
+          // Setup balloon popups
+          self.balloonTmpl = Hogan.compile(angular.element('#balloon_container').html());
+          self.balloon_deviceTmpl = Hogan.compile(angular.element('#balloon_device').html());
+          self.balloon_portTmpl = Hogan.compile(angular.element('#balloon_port').html());
+          self.balloon_netTmpl = Hogan.compile(angular.element('#balloon_net').html());
+          self.balloon_instanceTmpl = Hogan.compile(angular.element('#balloon_instance').html());
+          self.balloon_networkPortTmpl = Hogan.compile(angular.element('#balloon_network_port').html());
+
+          angular.element(document)
+            .on('click', 'a.closeTopologyBalloon', function(e) {
+              e.preventDefault();
+              self.delete_balloon();
+            })
+            .on('click', '.topologyBalloon', function(e) {
+              e.stopPropagation();
+            })
+            .on('click', 'a.vnc_window', function(e) {
+              e.preventDefault();
+              var vncWindow = window.open(angular.element(this).attr('href'), vncWindow, 'width=760,height=560');
+              self.delete_balloon();
+            });
+
+          angular.element('#toggle_labels').on('change', function() {
+            horizon.cookies.put('show_labels', this.checked);
+            self.refresh_labels();
+          });
+
+          angular.element('#toggle_networks').on('change', function() {
+            horizon.cookies.put('are_networks_collapsed', this.checked);
+            self.refresh_networks();
+            self.refresh_labels();
+          });
+
+          angular.element('#center_topology').on('click', function() {
+          this.blur(); // remove btn focus after click
+          self.delete_balloon();
+            // move visualization to the center and reset scale
+            self.vis.transition()
+              .duration(1500)
+              .attr('transform', 'translate(0,0)scale(1)');
+
+            // reset internal zoom translate and scale parameters so on next
+            // move the objects do not jump to the old position
+            self.zoom.translate([0,0]);
+            self.zoom.scale(1);
+            self.translate = null;
+          });
+          angular.element(window).on('message', function(e) {
+              var message = JSON.parse(e.originalEvent.data);
+              if (self.previous_message !== message.message) {
+                horizon.alert(message.type, message.message);
+                self.previous_message = message.message;
+                self.delete_post_message(message.iframe_id);
+                if (message.type == 'success' && self.deleting_device) {
+                  self.remove_node_on_delete();
+                }
+                self.retrieve_network_info();
+                setTimeout(function() {
+                  self.previous_message = null;
+                },10000);
+              }
+            });
+
+          // set up loader first thing
+          self.$loading_template.show();
+
+          self.create_vis();
+          self.force_direction(0.05,70,-700);
+          if(horizon.networktopologyloader.model !== null) {
+            self.retrieve_network_info(true);
+          }
+
+          d3.select(window).on('resize', function() {
+            var width = angular.element('#topologyCanvasContainer').width();
+            var height = angular.element('#topologyCanvasContainer').height();
+            self.force.size([width, height]).resume();
+          });
+
+          angular.element('#networktopology').on('change', function() {
+            self.retrieve_network_info(true);
+            if(angular.equals(self.data.networks,{}) && angular.equals(self.data.routers,{}) &&
+              angular.equals(self.data.servers,{}) && angular.equals(self.data.ports,{})){
+              $('.loader-inline').remove();
+              angular.element('#topologyCanvasContainer').find('svg').remove();
+              $(self.svg_container).addClass('noinfo');
+              return;
+            }
+          });
+
+          // register for message notifications
+          horizon.networktopologymessager.addMessageHandler(
+              this.handleMessage, this
+          );
+        },
+
+        // Shows/Hides graph labels
+        refresh_labels: function() {
+          var show_labels = horizon.cookies.get('show_labels') == 'true';
+          angular.element('.nodeLabel').toggle(show_labels);
+        },
+
+        // Collapses/Uncollapses networks in the graph
+        refresh_networks: function() {
+          var self = this;
+          var are_collapsed = horizon.cookies.get('are_networks_collapsed') == 'true';
+          for (var n in self.nodes) {
+            if ({}.hasOwnProperty.call(self.nodes, n)) {
+              if (self.nodes[n].data instanceof Network || self.nodes[n].data instanceof ExternalNetwork) {
+                  self.collapse_network(self.nodes[n], are_collapsed);
+              }
+            }
+          }
+        },
+
+        // Load config from cookie
+        load_config: function() {
+          var self = this;
+
+          var labels = horizon.cookies.get('show_labels') == 'true';
+          var networks = horizon.cookies.get('are_networks_collapsed') == 'true';
+
+          if(networks) {
+            angular.element('#toggle_networks_label').addClass('active');
+            angular.element('#toggle_networks').prop('checked', networks);
+            self.refresh_networks();
+          }
+
+          if(labels) {
+            angular.element('#toggle_labels_label').addClass('active');
+            angular.element('#toggle_labels').prop('checked', labels);
+            self.refresh_labels();
+          }
+        },
+
+        handleMessage:function(message) {
+          var self = this;
+          var deleteData = horizon.networktopologymessager.delete_data;
+          horizon.modals.spinner.modal('hide');
+          if (message.type == 'success') {
+            self.remove_node_on_delete(deleteData);
+          }
+        },
+
+        // Get the json data about the current deployment
+        retrieve_network_info: function(force_start) {
+          var self = this;
+          self.data_loaded = true;
+          self.load_topology(horizon.networktopologyloader.model);
+          if (force_start) {
+            var i = 0;
+            self.force.start();
+            while (i <= 100) {
+              self.force.tick();
+              i++;
+            }
+          }
+        },
+
+        getScreenCoords: function(x, y) {
+          var self = this;
+          if (self.translate) {
+            var xn = self.translate[0] + x * self.zoom.scale();
+            var yn = self.translate[1] + y * self.zoom.scale();
+            return { x: xn, y: yn };
+          } else {
+            return { x: x, y: y };
+          }
+        },
+
+        // Setup the main visualisation
+        create_vis: function() {
+          var self = this;
+          angular.element('#topologyCanvasContainer').find('svg').remove();
+
+          // Main svg
+          self.outer_group = d3.select('#topologyCanvasContainer').append('svg')
+            .attr('width', '100%')
+            .attr('height', '80vh')
+            .attr('style', 'border: solid')
+            .attr('pointer-events', 'all')
+            .append('g')
+            .call(self.zoom
+              .scaleExtent([0.1,1.5])
+              .on('zoom', function() {
+                  self.delete_balloon();
+                  self.vis.attr('transform', 'translate(' + d3.event.translate + ')scale(' +
+                    self.zoom.scale() + ')');
+                  self.translate = d3.event.translate;
+                })
+              )
+            .on('dblclick.zoom', null);
+
+          // Background for capturing mouse events
+          self.outer_group.append('rect')
+            .attr('width', '100%')
+            .attr('height', '100%')
+            .attr('fill', 'white')
+            .on('click', function() {
+              self.delete_balloon();
+            });
+
+          // svg wrapper for nodes to sit on
+          self.vis = self.outer_group.append('g');
+        },
+
+        // Calculate the hulls that surround networks
+        convex_hulls: function(nodes) {
+          var net, _i, _len, _ref, _h, i;
+          var hulls = {};
+          var networkids = {};
+          var k = 0;
+          var offset = 40;
+
+          while (k < nodes.length) {
+            var n = nodes[k];
+            if (n.data !== undefined) {
+              if (n.data instanceof Server) {
+                _ref = n.data.networks;
+                for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+                  net = _ref[_i];
+                  if (net instanceof Network) {
+                    _h = hulls[net.id] || (hulls[net.id] = []);
+                    _h.push([n.x - offset, n.y - offset]);
+                    _h.push([n.x - offset, n.y + offset]);
+                    _h.push([n.x + offset, n.y - offset]);
+                    _h.push([n.x + offset, n.y + offset]);
+                  }
+                }
+              } else if (n.data instanceof Network) {
+                net = n.data;
+                networkids[net.id] = n;
+                _h = hulls[net.id] || (hulls[net.id] = []);
+                _h.push([n.x - offset, n.y - offset]);
+                _h.push([n.x - offset, n.y + offset]);
+                _h.push([n.x + offset, n.y - offset]);
+                _h.push([n.x + offset, n.y + offset]);
+
+              }
+            }
+            ++k;
+          }
+          var hullset = [];
+          for (i in hulls) {
+            if ({}.hasOwnProperty.call(hulls, i)) {
+              hullset.push({group: i, network: networkids[i], path: d3.geom.hull(hulls[i])});
+            }
+          }
+
+          return hullset;
+        },
+
+        // Setup the force direction
+        force_direction: function(grav, dist, ch) {
+          var self = this;
+
+          angular.element('[data-toggle="tooltip"]').tooltip({container: 'body'});
+          self.curve = d3.svg.line()
+            .interpolate('cardinal-closed')
+            .tension(0.85);
+          self.fill = d3.scale.category10();
+
+          self.force = d3.layout.force()
+            .gravity(grav)
+            .linkDistance(function(d) {
+              if (d.source.data instanceof Server || d.target.data instanceof Server) {
+                if (d.source.data.connections) {
+                  return (dist * d.source.data.connections.length);
+                } else if (d.target.data.connections) {
+                  return (dist * d.target.data.connections.length);
+                }
+              } else if (d.source.data instanceof Router || d.target.data instanceof Router) {
+                if (d.source.data.networks) {
+                  if (d.source.data.networks.length === 0) {
+                    return dist + 20;
+                  } else if (d.target.data.instances) {
+                    return dist * d.source.data.networks.length + (10 * d.target.data.instances) + 20;
+                  }
+                  return dist * d.source.data.networks.length + 20;
+                } else if (d.target.data.networks) {
+                  if (d.target.data.networks.length === 0) {
+                    return dist + 20;
+                  } else if (d.source.data.instances) {
+                    return dist * d.target.data.networks.length + (10 * d.source.data.instances) + 20;
+                  }
+                  return dist * d.source.data.networks.length + 20;
+                }
+              } else {
+                return dist;
+              }
+            })
+            .charge(ch)
+            .size([angular.element('#topologyCanvasContainer').width(),
+                  angular.element('#topologyCanvasContainer').height()])
+            .nodes(self.nodes)
+            .links(self.links)
+            .on('tick', function() {
+              self.vis.selectAll('g.node')
+                .attr('transform', function(d) {
+                  return 'translate(' + d.x + ',' + d.y + ')';
+                });
+
+              self.vis.selectAll('line.link')
+                .attr('x1', function(d) { return d.source.x; })
+                .attr('y1', function(d) { return d.source.y; })
+                .attr('x2', function(d) { return d.target.x; })
+                .attr('y2', function(d) { return d.target.y; });
+
+              self.vis.selectAll('path.hulls')
+                .data(self.convex_hulls(self.vis.selectAll('g.node').data()))
+                  .attr('d', function(d) {
+                    return self.curve(d.path);
+                  })
+                .enter().insert('path', 'g')
+                  .attr('class', 'hulls')
+                  .style('fill', function(d) {
+                    return self.fill(d.group);
+                  })
+                  .style('stroke', function(d) {
+                    return self.fill(d.group);
+                  })
+                  .style('stroke-linejoin', 'round')
+                  .style('stroke-width', 10)
+                  .style('opacity', 0.2);
+            });
+        },
+
+        // Create a new node
+        new_node: function(data, x, y) {
+          var self = this;
+          data = {data: data};
+          if (x && y) {
+            data.x = x;
+            data.y = y;
+          }
+          self.nodes.push(data);
+          var node = self.vis.selectAll('g.node').data(self.nodes);
+          var nodeEnter = node.enter().append('g')
+            .attr('class', 'node')
+            .style('fill', 'white')
+            .call(self.force.drag);
+
+          nodeEnter.append('circle')
+            .attr('class', 'frame')
+            .attr('r', function(d) {
+              switch (Object.getPrototypeOf(d.data)) {
+                case ExternalNetwork.prototype:
+                  return 35;
+                case Server.prototype:
+                  return 30;
+                case Network.prototype:
+                  return 25;
+                case Router.prototype:
+                  return 25;
+                case Port.prototype:
+                  return 13;
+              }
+            })
+            .style('fill', 'white')
+            .style('stroke', 'black')
+            .style('stroke-width', 3);
+
+          switch (data.data.iconType) {
+            case 'text':
+              nodeEnter.append('text')
+                .style('fill', 'black')
+                .style('font', '20px FontAwesome')
+                .attr('text-anchor', 'middle')
+                .attr('dominant-baseline', 'central')
+                .text(function(d) { return d.data.icon; })
+                .attr('transform', function(d) {
+                  switch (Object.getPrototypeOf(d.data)) {
+                    case ExternalNetwork.prototype:
+                      return 'scale(2.5)';
+                    case Server.prototype:
+                      return 'scale(2)';
+                    case Network.prototype:
+                      return 'scale(1.5)';
+                    case Port.prototype:
+                      return 'scale(1)';
+                  }
+                });
+              break;
+            case 'path':
+              nodeEnter.append('path')
+                .attr('class', 'svgpath')
+                .style('fill', 'black')
+                .attr('d', function(d) { return self.svgs(d.data.svg); })
+                .attr('transform', function() {
+                  return 'scale(1.2)translate(-16,-15)';
+                });
+              break;
+          }
+
+          nodeEnter.append('text')
+            .attr('class', 'nodeLabel')
+            .style('display',function() {
+              var labels = horizon.cookies.get('topology_labels');
+              if (labels) {
+                return 'inline';
+              } else {
+                return 'none';
+              }
+            })
+            .style('fill','black')
+            .text(function(d) {
+              return d.data.name;
+            })
+            .attr('transform', function(d) {
+              switch (Object.getPrototypeOf(d.data)) {
+                case ExternalNetwork.prototype:
+                  return 'translate(40,3)';
+                case Server.prototype:
+                  return 'translate(35,3)';
+                case Network.prototype:
+                  return 'translate(30,3)';
+                case Router.prototype:
+                  return 'translate(30,3)';
+                case Port.prototype:
+                  return 'translate(20,3)';
+              }
+            });
+
+          if (data.data instanceof Network || data.data instanceof ExternalNetwork) {
+            nodeEnter.append('svg:text')
+              .attr('class','vmCount')
+              .style('fill', 'black')
+              .style('font-size','20')
+              .text('')
+              .attr('transform', 'translate(26,38)');
+          }
+
+          nodeEnter.on('click', function(d) {
+            self.show_balloon(d.data, d, angular.element(this));
+          });
+
+          // Highlight the links for currently selected node
+          nodeEnter.on('mouseover', function(d) {
+            self.vis.selectAll('line.link').filter(function(z) {
+              if (z.source === d || z.target === d) {
+                return true;
+              } else {
+                return false;
+              }
+            }).style('stroke-width', '3px');
+          });
+
+          // Remove the highlight on the links
+          nodeEnter.on('mouseout', function() {
+            self.vis.selectAll('line.link').style('stroke-width','1px');
+          });
+        },
+
+        collapse_network: function(d, only_collapse) {
+          var self = this;
+          var server, vm;
+
+          var filterNode = function(obj) {
+            return function(d) {
+              return obj == d.data;
+            };
+          };
+
+          if (!d.data.collapsed) {
+            var vmCount = 0;
+            for (vm in self.data.servers) {
+              if (self.data.servers[vm] !== undefined) {
+                if (self.data.servers[vm].networks.length == 1) {
+                  if (self.data.servers[vm].networks[0].id == d.data.id) {
+                    vmCount += 1;
+                    self.removeNode(self.data.servers[vm]);
+                  }
+                }
+              }
+            }
+            d.data.collapsed = true;
+            if (vmCount > 0) {
+              self.vis.selectAll('.vmCount').filter(filterNode(d.data))[0][0].textContent = vmCount;
+            }
+          } else if (!only_collapse) {
+            for (server in self.data.servers) {
+              if ({}.hasOwnProperty.call(self.data.servers, server)) {
+                var _vm = self.data.servers[server];
+                if (_vm !== undefined) {
+                  if (_vm.networks.length === 1) {
+                    if (_vm.networks[0].id == d.data.id) {
+                      self.new_node(_vm, d.x, d.y);
+                      self.new_link(self.find_by_id(_vm.id), self.find_by_id(d.data.id));
+                      self.force.start();
+                    }
+                  }
+                }
+              }
+            }
+            d.data.collapsed = false;
+            self.vis.selectAll('.vmCount').filter(filterNode(d.data))[0][0].textContent = '';
+            var i = 0;
+            while (i <= 100) {
+              self.force.tick();
+              i++;
+            }
+          }
+        },
+
+        new_link: function(source, target) {
+          var self = this;
+          self.links.push({source: source, target: target});
+          var line = self.vis.selectAll('line.link').data(self.links);
+          line.enter().insert('line', 'g.node')
+            .attr('class', 'link')
+            .attr('x1', function(d) { return d.source.x; })
+            .attr('y1', function(d) { return d.source.y; })
+            .attr('x2', function(d) { return d.target.x; })
+            .attr('y2', function(d) { return d.target.y; })
+            .style('stroke', 'black')
+            .style('stroke-width', 2);
+        },
+
+        find_by_id: function(id) {
+          var self = this;
+          var obj, _i, _len, _ref;
+          _ref = self.vis.selectAll('g.node').data();
+          for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+            obj = _ref[_i];
+            if (obj.data.id == id) {
+              return obj;
+            }
+          }
+          return undefined;
+        },
+
+        already_in_graph: function(data, node) {
+          // Check for gateway that may not have unique id
+          if (data == this.data.ports) {
+            for (var p in data) {
+              if (JSON.stringify(data[p]) == JSON.stringify(node)) {
+                return true;
+              }
+            }
+            return false;
+          }
+          // All other node types have UUIDs
+          for (var n in data) {
+            if (n == node.id) {
+              return true;
+            }
+          }
+          return false;
+        },
+
+        load_topology: function(data) {
+          var self = this;
+          var net, _i, _netlen, _netref, rou, _j, _roulen, _rouref, port, _l, _portlen, _portref,
+              ser, _k, _serlen, _serref, obj, vmCount;
+          var change = false;
+          var filterNode = function(obj) {
+            return function(d) {
+              return obj == d.data;
+            };
+          };
+
+          // Networks
+          _netref = data.networks;
+          for (_i = 0, _netlen = _netref.length; _i < _netlen; _i++) {
+            net = _netref[_i];
+            var network = null;
+            if (net['router:external'] === true) {
+              network = new ExternalNetwork(net);
+            } else {
+              network = new Network(net);
+            }
+
+            if (!self.already_in_graph(self.data.networks, network)) {
+              self.new_node(network);
+              change = true;
+            } else {
+              obj = self.find_by_id(network.id);
+              if (obj) {
+                network.collapsed = obj.data.collapsed;
+                network.instances = obj.data.instances;
+                obj.data = network;
+              }
+            }
+            self.data.networks[network.id] = network;
+          }
+
+          // Routers
+          _rouref = data.routers;
+          for (_j = 0, _roulen = _rouref.length; _j < _roulen; _j++) {
+            rou = _rouref[_j];
+            var router = new Router(rou);
+            if (!self.already_in_graph(self.data.routers, router)) {
+              self.new_node(router);
+              change = true;
+            } else {
+              obj = self.find_by_id(router.id);
+              if (obj) {
+                // Keep networks list
+                router.networks = obj.data.networks;
+                // Keep ports list
+                router.ports = obj.data.ports;
+                obj.data = router;
+              }
+            }
+            self.data.routers[router.id] = router;
+          }
+
+          // Servers
+          _serref = data.servers;
+          for (_k = 0, _serlen = _serref.length; _k < _serlen; _k++) {
+            ser = _serref[_k];
+            var server = new Server(ser);
+            if (!self.already_in_graph(self.data.servers, server)) {
+              self.new_node(server);
+              change = true;
+            } else {
+              obj = self.find_by_id(server.id);
+              if (obj) {
+                // Keep networks list
+                server.networks = obj.data.networks;
+                // Keep connections list
+                server.connections = obj.data.connections;
+                obj.data = server;
+              } else if (self.data.servers[server.id] !== undefined) {
+                // This is used when servers are hidden because the network is
+                // collapsed
+                  server.networks = self.data.servers[server.id].networks;
+                  server.connections = self.data.servers[server.id].connections;
+              }
+            }
+            self.data.servers[server.id] = server;
+          }
+
+          // Ports
+          _portref = data.ports;
+          ports_to_delete = {};
+          for (_l = 0, _portlen = _portref.length; _l < _portlen; _l++) {
+            var prt = _portref[_l];
+            port = new Port(prt);
+            if (!self.already_in_graph(self.data.ports, port)) {
+              var device = self.find_by_id(port.device_id);
+              var _network = self.find_by_id(port.network_id);
+              if (angular.isDefined(device) && angular.isDefined(_network)) {
+                if (port.device_owner && port.device_owner.startsWith('compute:')) {
+                  _network.data.instances++;
+                  device.data.networks.push(_network.data);
+                  if (port.fixed_ips) {
+                    for(var ip in port.fixed_ips) {
+                      if (!listContains(port.fixed_ips[ip], device.data.ip_addresses)) {
+                        device.data.ip_addresses.push(port.fixed_ips[ip]);
+                      }
+                    }
+                  }
+                  // Remove the recently added node if connected to a network which is
+                  // currently collapsed
+                  if (_network.data.collapsed) {
+                    if (device.data.networks.length == 1) {
+                      self.data.servers[device.data.id].networks = device.data.networks;
+                      self.data.servers[device.data.id].ip_addresses = device.data.ip_addresses;
+                      self.removeNode(self.data.servers[port.device_id]);
+                      vmCount = Number(self.vis.selectAll('.vmCount').filter(filterNode(_network.data))[0][0].textContent);
+                      self.vis.selectAll('.vmCount').filter(filterNode(_network.data))[0][0].textContent = vmCount + 1;
+                      continue;
+                    }
+                  }
+                } else if (port.device_owner == 'network:router_interface') {
+                  device.data.networks.push(_network.data);
+                  device.data.ports.push(port);
+                } else if (device.data.ports) {
+                  device.data.ports.push(port);
+                }
+                self.new_link(self.find_by_id(port.device_id), self.find_by_id(port.network_id));
+                change = true;
+              } else if (angular.isDefined(_network) &&
+                        port.device_owner && port.device_owner.startsWith('compute:')) {
+                // Need to add a previously hidden node to the graph because it is
+                // connected to more than 1 network
+                if (_network.data.collapsed) {
+                  server = self.data.servers[port.device_id];
+                  server.networks.push(_network.data);
+                  if (port.fixed_ips) {
+                    for(var ip in port.fixed_ips) {
+                      server.ip_addresses.push(port.fixed_ips[ip]);
+                    }
+                  }
+                  self.new_node(server);
+                  // decrease collapsed vm count on network
+                  vmCount = Number(self.vis.selectAll('.vmCount').filter(filterNode(server.networks[0]))[0][0].textContent);
+                  if (vmCount == 1) {
+                    self.vis.selectAll('.vmCount').filter(filterNode(server.networks[0]))[0][0].textContent = '';
+                  } else {
+                    self.vis.selectAll('.vmCount').filter(filterNode(server.networks[0]))[0][0].textContent = vmCount - 1;
+                  }
+                  // Add back in first network link
+                  self.new_link(self.find_by_id(port.device_id), self.find_by_id(server.networks[0].id));
+                  // Add new link
+                  self.new_link(self.find_by_id(port.device_id), self.find_by_id(port.network_id));
+                  change = true;
+                }
+              } else if (angular.isDefined(_network) &&
+                        (port.device_owner && port.device_owner.startsWith('baremetal:') || port.name)) {
+
+                self.new_node(port);
+                change = true;
+
+                self.new_link(self.find_by_id(port.id), self.find_by_id(port.network_id));
+
+                if (port.server_ids.length === 0) {
+                  ports_to_delete[port.id] = port;
+                } else {
+                  port.server_ids.forEach(function(server_id) {
+                    self.new_link(self.find_by_id(port.id), self.find_by_id(server_id));
+                  });
+                }
+
+                if (port.sub_ports.length > 0) {
+                  port.sub_ports.forEach(function(sub_port) {
+                    delete ports_to_delete[sub_port.port_id];
+                    self.new_link(self.find_by_id(port.id), self.find_by_id(sub_port.port_id));
+                  });
+                }
+              }
+            }
+            self.data.ports[port.id] = port;
+          }
+
+          for (const id in ports_to_delete) {
+            self.removeLink(self.links.find(function(link) {
+              link.source === ports_to_delete[id];
+            }));
+            self.removeNode(ports_to_delete[id]);
+          }
+          
+          if (change) {
+              self.force.start();
+          }
+          self.load_config();
+          self.$loading_template.hide();
+        },
+
+        removeNode: function(obj) {
+          var filterNetwork, filterNode, n, node, _i, _len, _ref;
+          _ref = this.nodes;
+          for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+            n = _ref[_i];
+            if (n.data === obj) {
+              node = n;
+              break;
+            }
+          }
+          if (node) {
+            this.nodes.splice(this.nodes.indexOf(node), 1);
+            filterNode = function(obj) {
+              return function(d) {
+                return obj === d.data;
+              };
+            };
+            filterNetwork = function(obj) {
+              return function(d) {
+                return obj === d.network.data;
+              };
+            };
+            if (obj instanceof Network) {
+              this.vis.selectAll('.hulls').filter(filterNetwork(obj)).remove();
+            }
+            this.vis.selectAll('g.node').filter(filterNode(obj)).remove();
+            return this.removeNodesLinks(obj);
+          }
+        },
+
+        removeNodesLinks: function(node) {
+          var l, linksToRemove, _i, _j, _len, _len1, _ref;
+          linksToRemove = [];
+          _ref = this.links;
+          for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+            l = _ref[_i];
+            if (l.source.data === node) {
+              linksToRemove.push(l);
+            } else if (l.target.data === node) {
+              linksToRemove.push(l);
+            }
+          }
+          for (_j = 0, _len1 = linksToRemove.length; _j < _len1; _j++) {
+            l = linksToRemove[_j];
+            this.removeLink(l);
+          }
+          return this.force.resume();
+        },
+
+        removeLink: function(link) {
+          var i, index, l, _i, _len, _ref;
+          index = -1;
+          _ref = this.links;
+          for (i = _i = 0, _len = _ref.length; _i < _len; i = ++_i) {
+            l = _ref[i];
+            if (l === link) {
+              index = i;
+              break;
+            }
+          }
+          if (index !== -1) {
+            this.links.splice(index, 1);
+          }
+          return this.vis.selectAll('line.link').data(this.links).exit().remove();
+        },
+
+        delete_device: function(device_type, deviceId) {
+          var message = {id:deviceId};
+          var target = device_type === 'instance' ? 'instance?id=' + deviceId : device_type;
+          horizon.networktopologymessager.post_message(deviceId, target, message, device_type, 'delete', data={});
+        },
+
+        remove_node_on_delete: function(deleteData) {
+          var self = this;
+          var deviceId = deleteData.device_id;
+          switch (deleteData.device_type) {
+            case 'router':
+              self.removeNode(self.data.routers[deviceId]);
+              break;
+            case 'instance':
+              self.removeNode(self.data.servers[deviceId]);
+              this.data.servers[deviceId] = undefined;
+              break;
+            case 'network':
+              self.removeNode(self.data.networks[deviceId]);
+              break;
+            case 'port':
+              self.removePortOrSubnet(deviceId, deleteData.device_data);
+              break;
+          }
+          self.delete_balloon();
+        },
+
+        removePortOrSubnet: function(portId, deviceData) {
+          var self = this;
+          var routerId = deviceData.router_id;
+          var networkId = deviceData.network_id;
+          if (routerId) {
+            for (var l in self.links) {
+              var data = null;
+              if(self.links[l].source.data.id == routerId && self.links[l].target.data.id == networkId) {
+                data = self.links[l].source.data;
+              } else if (self.links[l].target.data.id == routerId && self.links[l].source.data.id == networkId) {
+                data = self.links[l].target.data;
+              }
+              if (data) {
+                for (var p in data.ports) {
+                  if ((data.ports[p].id == portId) && (data.ports[p].network_id == networkId)) {
+                    self.removeLink(self.links[l]);
+                    // Update Router to remove deleted port
+                    var router = self.find_by_id(routerId);
+                    router.data.ports.splice(router.data.ports.indexOf(data.ports[p]), 1);
+                    self.force.start();
+                    return;
+                  }
+                }
+              }
+            }
+          } else {
+            var networkData = self.find_by_id(networkId).data;
+            var subnets = networkData.subnets;
+            for (var subnet in subnets) {
+              if (subnets[subnet].id === portId) {
+                if (subnets.length == 1) {
+                  delete(networkData.subnets);
+                } else {
+                  subnets.splice(subnet, 1);
+                }
+                self.force.start();
+                break;
+              }
+            }
+          }
+        },
+
+        delete_port: function(routerId, portId, networkId) {
+          var message = {id:portId};
+          var data = {network_id:networkId,router_id:routerId};
+          if (routerId) {
+            horizon.networktopologymessager.post_message(portId, 'router/' + routerId + '/', message, 'port', 'delete', data);
+          } else {
+            horizon.networktopologymessager.post_message(portId, 'network/' + networkId + '/?tab=network_tabs__subnets_tab', message, 'port', 'delete', data);
+          }
+        },
+
+        show_balloon: function(d,d2,element) {
+          var self = this;
+          var balloonTmpl = self.balloonTmpl;
+          var deviceTmpl = self.balloon_deviceTmpl;
+          var portTmpl = self.balloon_portTmpl;
+          var netTmpl = self.balloon_netTmpl;
+          var instanceTmpl = self.balloon_instanceTmpl;
+          var networkPortTmpl = self.balloon_networkPortTmpl;
+          var balloonID = 'bl_' + d.id;
+          var ports = [];
+          var subnets = [];
+          if (self.balloonID) {
+            if (self.balloonID == balloonID) {
+              self.delete_balloon();
+              return;
+            }
+            self.delete_balloon();
+          }
+          self.force.stop();
+          if (d.hasOwnProperty('ports')) {
+            angular.element.each(d.ports, function(i, port) {
+              var object = {};
+              object.id = port.id;
+              object.router_id = port.device_id;
+              object.url = port.url;
+              object.port_status = port.status;
+              object.port_status_class = (port.original_status === 'ACTIVE') ? 'active' : 'down';
+              var ipAddress = '';
+              try {
+                for (var ip in port.fixed_ips) {
+                  ipAddress += port.fixed_ips[ip].ip_address + ' ';
+                }
+              }catch(e) {
+                ipAddress = gettext('None');
+              }
+              var deviceOwner = '';
+              try {
+                deviceOwner = port.device_owner.replace('network:','');
+              }catch(e) {
+                deviceOwner = gettext('None');
+              }
+              var networkId = '';
+              try {
+                networkId = port.network_id;
+              }catch(e) {
+                networkId = gettext('None');
+              }
+              object.ip_address = ipAddress;
+              object.device_owner = deviceOwner;
+              object.network_id = networkId;
+              object.is_interface = (
+                deviceOwner === 'router_interface' ||
+                deviceOwner === 'router_gateway' ||
+                deviceOwner === 'ha_router_replicated_interface'
+              );
+              ports.push(object);
+            });
+          } else if (d.hasOwnProperty('subnets')) {
+            angular.element.each(d.subnets, function(i, snet) {
+              var object = {};
+              object.id = snet.id;
+              object.cidr = snet.cidr;
+              object.url = snet.url;
+              subnets.push(object);
+            });
+          }
+          var htmlData = {
+            balloon_id:balloonID,
+            id:d.id,
+            url:d.url,
+            name:d.name,
+            type:d.type,
+            delete_label: gettext('Delete'),
+            status:d.status,
+            status_class: (d.original_status === 'ACTIVE') ? 'active' : 'down',
+            status_label: gettext('STATUS'),
+            id_label: gettext('ID'),
+            interfaces_label: gettext('Interfaces'),
+            subnets_label: gettext('Subnets'),
+            delete_interface_label: gettext('Delete Interface'),
+            delete_subnet_label: gettext('Delete Subnet'),
+            open_console_label: gettext('Open Console'),
+            view_details_label: gettext('View Details'),
+            server_connections_label: gettext('Connections')
+          };
+          var html;
+          if (d instanceof Router) {
+            htmlData.delete_label = gettext('Delete Router');
+            htmlData.view_details_label = gettext('View Router Details');
+            htmlData.port = ports;
+            htmlData.add_interface_url = 'router/' + d.id + '/addinterface';
+            htmlData.add_interface_label = gettext('Add Interface');
+            html = balloonTmpl.render(htmlData,{
+              table1:deviceTmpl,
+              table2:portTmpl
+            });
+          } else if (d instanceof Server) {
+            htmlData.delete_label = gettext('Delete Instance');
+            htmlData.view_details_label = gettext('View Instance Details');
+            htmlData.console_id = d.id;
+            htmlData.connections = d.connections;
+            htmlData.console = d.console;
+            html = balloonTmpl.render(htmlData,{
+              table1:deviceTmpl,
+              table2:instanceTmpl
+            });
+          } else if (d instanceof Port) {
+            htmlData.delete_label = gettext('Delete Port');
+            htmlData.view_details_label = gettext('View Port Details');
+            htmlData.fixed_ips = d.fixed_ips;
+            htmlData.sub_ports = d.sub_ports;
+            htmlData.floating_ips = d.floating_ips;
+            html = balloonTmpl.render(htmlData,{
+              table1:deviceTmpl,
+              table2:networkPortTmpl
+            });
+          } else if (d instanceof Network || d instanceof ExternalNetwork) {
+            for (var s in subnets) {
+              subnets[s].network_id = d.id;
+            }
+            htmlData.subnet = subnets;
+            if (d instanceof Network) {
+              htmlData.delete_label = gettext('Delete Network');
+              if (d.allow_delete_subnet){
+                htmlData.allow_delete_subnet = d.allow_delete_subnet;
+              }
+            }
+            htmlData.add_subnet_url = 'network/' + d.id + '/subnet/create';
+            htmlData.add_subnet_label = gettext('Create Subnet');
+            html = balloonTmpl.render(htmlData,{
+              table1:deviceTmpl,
+              table2:netTmpl
+            });
+          } else {
+            return;
+          }
+          angular.element(self.svg_container).append(html);
+          var devicePosition = self.getScreenCoords(d2.x, d2.y);
+          var x = devicePosition.x;
+          var y = devicePosition.y;
+          var xoffset = 100;
+          var yoffset = 95;
+          angular.element('#' + balloonID).css({
+            'left': x + xoffset + 'px',
+            'top': y + yoffset + 'px'
+          }).show();
+          var _balloon = angular.element('#' + balloonID);
+          if (element.x + _balloon.outerWidth() > angular.element(window).outerWidth()) {
+            _balloon
+              .css({
+                'left': 0 + 'px'
+              })
+              .css({
+                'left': (x - _balloon.outerWidth() + 'px')
+              })
+              .addClass('leftPosition');
+          }
+          _balloon.find('.delete-device').on('click', function() {
+            var _this = angular.element(this);
+            var delete_modal = horizon.datatables.confirm(_this);
+            delete_modal.find('.btn.btn-danger').on('click', function () {
+              _this.prop('disabled', true);
+              d3.select('#id_' + _this.data('device-id')).classed('loading',true);
+              self.delete_device(_this.data('type'),_this.data('device-id'));
+            });
+          });
+          _balloon.find('.delete-port').on('click', function() {
+            var _this = angular.element(this);
+            var delete_modal = horizon.datatables.confirm(_this);
+            delete_modal.find('.btn.btn-danger').on('click', function () {
+              _this.prop('disabled', true);
+              self.delete_port(_this.data('router-id'),_this.data('port-id'),_this.data('network-id'));
+            });
+          });
+          self.balloonID = balloonID;
+        },
+
+        delete_balloon:function() {
+          var self = this;
+          if (self.balloonID) {
+            angular.element('#' + self.balloonID).remove();
+            self.balloonID = null;
+            self.force.start();
+          }
+        },
+
+        svgs: function(name) {
+          switch (name) {
+            case 'router':
+              return 'm 26.628571,16.08 -8.548572,0 0,8.548571 2.08,-2.079998 6.308572,6.30857 4.38857,-4.388572 -6.308571,-6.30857 z m -21.2571429,-4.159999 8.5485709,0 0,-8.5485723 -2.08,2.08 L 5.5314281,-0.85714307 1.1428571,3.5314287 7.4514281,9.84 z m -3.108571,7.268571 0,8.548571 8.5485709,0 L 8.7314281,25.657144 15.039999,19.325715 10.674285,14.96 4.3428571,21.268573 z M 29.737142,8.8114288 l 0,-8.54857147 -8.548572,0 2.08,2.07999987 -6.308571,6.3085716 4.388572,4.3885722 6.308571,-6.3085723 z';
+            default:
+              return '';
+          }
+        }
+      };
+
+      if (typeof horizon.network_topology !== 'undefined') {
+        horizon.baremetal_topology.init();
+      } else {
+        addHorizonLoadEvent(function () {
+          horizon.networktopologycommon.init();
+          horizon.baremetal_topology.init();
+        });
+      }
+    </script>
+  </div>
+</div>
+{% endblock %}

--- a/esi_ui/content/baremetal_topology/urls.py
+++ b/esi_ui/content/baremetal_topology/urls.py
@@ -1,0 +1,9 @@
+from django.urls import re_path
+
+import esi_ui.api.esi_rest_api
+from esi_ui.content.baremetal_topology import views
+
+urlpatterns = [
+    re_path(r'^$', views.IndexView.as_view(), name='index'),
+    re_path(r'^json$', views.ESIJSONView.as_view(), name='json'),
+]

--- a/esi_ui/content/baremetal_topology/views.py
+++ b/esi_ui/content/baremetal_topology/views.py
@@ -1,0 +1,93 @@
+import concurrent.futures
+
+from django.views import generic
+
+from esi.lib import nodes
+from esi_ui.api import esi_api
+from openstack_dashboard.dashboards.project.network_topology import views as topology_view
+
+
+class IndexView(generic.TemplateView):
+    template_name = 'project/baremetal_topology/index.html'
+
+
+class ESIJSONView(topology_view.JSONView):
+    def _get_servers(self, request):
+        try:
+            node_networks = nodes.network_list(esi_api.esiclient(request.user.token.id))
+        except Exception:
+            node_networks = []
+
+        data = [
+            {
+                'id': node_network['node'].id,
+                'name': node_network['node'].name,
+                'connections': [
+                    {
+                        'mac_address': info['baremetal_port'].address,
+                        'port_name': info['network_ports'][0].name if len(info['network_ports']) else '',
+                    }
+                    for info in node_network['network_info']
+                ],
+            }
+            for node_network in node_networks
+        ]
+        return data
+
+    def _get_ports(self, request, networks):
+        token = request.user.token.id
+        try:
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                f1 = executor.submit(esi_api.esiclient(token).network.ports)
+                f2 = executor.submit(esi_api.esiclient(token).baremetal.ports, details=True)
+                f3 = executor.submit(esi_api.esiclient(token).network.ips)
+                network_ports = list(f1.result())
+                port_name_dict = {port.id: port.name for port in network_ports}
+                
+                node_id_dict = {}
+                for port in f2.result():
+                    port_id = port.internal_info.get('tenant_vif_port_id')
+                    if port_id in node_id_dict:
+                        node_id_dict[port_id].append(port.node_id)
+                    elif port_id:
+                        node_id_dict[port_id] = [port.node_id]
+
+                floating_ips_dict = {}
+                for fip in f3.result():
+                    if fip.port_id in floating_ips_dict:
+                        floating_ips_dict[fip.port_id].append(fip.floating_ip_address)
+                    else:
+                        floating_ips_dict[fip.port_id] = [fip.floating_ip_address]
+        except Exception:
+            network_ports = []
+
+        for port in network_ports:
+            if getattr(port, 'trunk_details') and port.trunk_details.get('sub_ports', []):
+                for subport in port.trunk_details['sub_ports']:
+                    subport['name'] = port_name_dict[subport['port_id']]
+
+        tenant_network_ids = [network['id'] for network in networks]
+        ports = [
+            {
+                'id': port.id,
+                'name': port.name,
+                'network_id': port.network_id,
+                'server_ids': node_id_dict.get(port.id, []),
+                'mac_address': port.mac_address,
+                'sub_ports': port.trunk_details.get('sub_ports', []) if getattr(port, 'trunk_details') is not None else [],
+                'device_id': port.device_id,
+                'fixed_ips': port.fixed_ips,
+                'floating_ips': floating_ips_dict.get(port.id, []),
+                'device_owner': port.device_owner,
+                'status': self.trans.port[port.status],
+                'original_status': port.status,
+            }
+            for port in network_ports
+            if (port.device_owner != 'network:router_ha_interface' and
+                port.network_id in tenant_network_ids)
+        ]
+
+        # trunk ports at the end because the javascript needs to process the others first
+        ports.sort(key=lambda port: len(port['sub_ports']) != 0)
+
+        return ports

--- a/esi_ui/enabled/_6030_project_network_topology_panel.py
+++ b/esi_ui/enabled/_6030_project_network_topology_panel.py
@@ -1,0 +1,27 @@
+# The name of the panel to be added to HORIZON_CONFIG. Required.
+PANEL = 'baremetal_topology'
+
+# The name of the dashboard the PANEL associated with. Required.
+PANEL_DASHBOARD = 'project'
+PANEL_GROUP = 'esi'
+
+# Python panel class of the PANEL to be added.
+ADD_PANEL = 'esi_ui.content.baremetal_topology.panel.BaremetalTopology'
+
+# A list of applications to be prepended to INSTALLED_APPS
+#ADD_INSTALLED_APPS = ['esi_ui']
+
+# A list of AngularJS modules to be loaded when Angular bootstraps.
+#ADD_ANGULAR_MODULES = ['horizon.dashboard.project.esi']
+
+# Automatically discover static resources in installed apps
+AUTO_DISCOVER_STATIC_FILES = True
+
+# A list of js files to be included in the compressed set of files
+#ADD_JS_FILES = []
+
+# A list of scss files to be included in the compressed set of files
+#ADD_SCSS_FILES = ['dashboard/identity/myplugin/mypanel/mypanel.scss']
+
+# A list of template-based views to be added to the header
+#ADD_HEADER_SECTIONS = ['esi_ui.content.esi_nodes.views.HeaderView',]


### PR DESCRIPTION
In the dashboard, if you click on Network > Network Topology, it shows a graph topology of the networks and instances. This panel does not work for baremetal nodes which ESI uses. This adds a topology view of the baremetal nodes and their MAC address connections to network ports in addition to the already existing network topology.