### PR TITLE
Confirmation before unprovisioning

### DIFF
--- a/esi_ui/static/dashboard/project/esi/nodes/esi-nodes-table.module.js
+++ b/esi_ui/static/dashboard/project/esi/nodes/esi-nodes-table.module.js
@@ -6,6 +6,7 @@
       'horizon.dashboard.project.esi.nodes.manage-networks',
       'horizon.dashboard.project.esi.nodes.manage-floating-ips',
       'horizon.dashboard.project.esi.nodes.provisioning',
+      'horizon.dashboard.project.esi.nodes.unprovisioning',
       'horizon.dashboard.project.esi.nodes.delete-leases'
     ])
     .config(config);

--- a/esi_ui/static/dashboard/project/esi/nodes/unprovisioning/unprovisioning-modal.service.js
+++ b/esi_ui/static/dashboard/project/esi/nodes/unprovisioning/unprovisioning-modal.service.js
@@ -1,0 +1,38 @@
+(function () {
+  'use strict';
+
+  angular
+    .module('horizon.dashboard.project.esi.nodes.unprovisioning')
+    .factory(
+      'horizon.dashboard.project.esi.nodes.unprovisioning.modal.service',
+      UnprovisioningModalService
+    );
+
+  UnprovisioningModalService.$inject = [
+    '$uibModal',
+    'horizon.dashboard.project.esi.nodes.unprovisioning.modal-spec'
+  ];
+
+  function UnprovisioningModalService($uibModal, modalSpec) {
+    var service = {
+      open: open
+    };
+
+    return service;
+
+    function open(launchContext) {
+      var localSpec = {
+        resolve: {
+          launchContext: function () {
+            return launchContext;
+          }
+        }
+      };
+
+      angular.extend(localSpec, modalSpec);
+
+      return $uibModal.open(localSpec).result;
+    }
+  }
+
+})();

--- a/esi_ui/static/dashboard/project/esi/nodes/unprovisioning/unprovisioning-wizard.controller.js
+++ b/esi_ui/static/dashboard/project/esi/nodes/unprovisioning/unprovisioning-wizard.controller.js
@@ -1,0 +1,26 @@
+(function () {
+    'use strict';
+  
+    angular
+      .module('horizon.dashboard.project.esi.nodes.unprovisioning')
+      .controller('UnprovisioningWizardController', UnprovisioningWizardController);
+  
+    UnprovisioningWizardController.$inject = [
+      '$scope',
+      'horizon.dashboard.project.esi.nodes.unprovisioning.workflow'
+    ];
+  
+    function UnprovisioningWizardController($scope, unprovisioningWorkflow) {
+      $scope.workflow = unprovisioningWorkflow;
+      $scope.submit = submit;
+    
+      // console.log($scope.launchContext.nodes);
+      function submit(stepModels) {
+        return Promise.resolve({
+            unprovisionNodes: stepModels.unprovisionNodes
+        });
+      }
+    }
+  
+  })();
+  

--- a/esi_ui/static/dashboard/project/esi/nodes/unprovisioning/unprovisioning-workflow.service.js
+++ b/esi_ui/static/dashboard/project/esi/nodes/unprovisioning/unprovisioning-workflow.service.js
@@ -1,0 +1,36 @@
+(function () {
+    'use strict';
+
+    angular
+      .module('horizon.dashboard.project.esi.nodes.unprovisioning')
+      .factory('horizon.dashboard.project.esi.nodes.unprovisioning.workflow', unprovisioningWorkflow);
+
+    unprovisioningWorkflow.$inject = [
+      'horizon.dashboard.project.esi.nodes.unprovisioning.basePath',
+      'horizon.app.core.workflow.factory'
+    ];
+
+    function unprovisioningWorkflow(basePath, dashboardWorkflow) {
+      return dashboardWorkflow({
+        title: gettext('Unprovision Node'),
+
+        steps: [
+          {
+            id: 'unprovision',
+            title: gettext('Unprovision'),
+            templateUrl: basePath + 'unprovisioning.html',
+            formName: 'unprovisionForm'
+          },
+        ],
+
+        btnText: {
+          finish: gettext('Unprovision')
+        },
+
+        btnIcon: {
+          finish: 'fa-times'
+        }
+      });
+    }
+
+})();

--- a/esi_ui/static/dashboard/project/esi/nodes/unprovisioning/unprovisioning.html
+++ b/esi_ui/static/dashboard/project/esi/nodes/unprovisioning/unprovisioning.html
@@ -1,0 +1,12 @@
+<p class="step-description" translate>Are you sure you want to unprovision the selected node(s)? This action is irreversible.</p>
+
+<span ng-repeat="node in launchContext.nodes">
+  <div class="form-group">
+    <label class="control-label" translate for="node_name">{$ node.name $}</label>
+    <div class="alert alert-info">
+      <p>Node Name: {$ node.name $}</p>
+      <p>Provision State: {$ node.provision_state $}</p>
+    </div>
+  </div>
+</span>
+

--- a/esi_ui/static/dashboard/project/esi/nodes/unprovisioning/unprovisioning.module.js
+++ b/esi_ui/static/dashboard/project/esi/nodes/unprovisioning/unprovisioning.module.js
@@ -1,0 +1,24 @@
+(function () {
+    'use strict';
+
+    angular
+        .module('horizon.dashboard.project.esi.nodes.unprovisioning', [])
+        .config(config)
+        .constant('horizon.dashboard.project.esi.nodes.unprovisioning.modal-spec', {
+            backdrop: 'static',
+            size: 'lg',
+            controller: 'ModalContainerController',
+            template: '<wizard class="wizard" ng-controller="UnprovisioningWizardController"></wizard>'
+        });
+
+    config.$inject = [
+        '$provide',
+        '$windowProvider'
+    ];
+
+    function config($provide, $windowProvider) {
+        var basePath = $windowProvider.$get().STATIC_URL + 'dashboard/project/esi/nodes/unprovisioning/';
+        $provide.constant('horizon.dashboard.project.esi.nodes.unprovisioning.basePath', basePath);
+    }
+
+})();


### PR DESCRIPTION
**Title:**
Confirmation Before Unprovisioning Nodes

**Summary:**

This pull request implements a feature that provides a confirmation modal before unprovisioning nodes. The modal displays relevant node details and asks the user for confirmation before proceeding with the irreversible unprovisioning action.