### PR TITLE
Check if token is project scoped; if not, create a project scoped token

### DIFF
--- a/esi_ui/content/esi/lessee/baremetal_topology/views.py
+++ b/esi_ui/content/esi/lessee/baremetal_topology/views.py
@@ -14,7 +14,7 @@ class IndexView(generic.TemplateView):
 class ESIJSONView(topology_view.JSONView):
     def _get_servers(self, request):
         try:
-            node_networks = nodes.network_list(esi_api.esiclient(request.user.token.id))
+            node_networks = nodes.network_list(esi_api.esiclient(request))
         except Exception:
             node_networks = []
 
@@ -35,12 +35,11 @@ class ESIJSONView(topology_view.JSONView):
         return data
 
     def _get_ports(self, request, networks):
-        token = request.user.token.id
         try:
             with concurrent.futures.ThreadPoolExecutor() as executor:
-                f1 = executor.submit(esi_api.esiclient(token).network.ports)
-                f2 = executor.submit(esi_api.esiclient(token).baremetal.ports, details=True)
-                f3 = executor.submit(esi_api.esiclient(token).network.ips)
+                f1 = executor.submit(esi_api.esiclient(request).network.ports)
+                f2 = executor.submit(esi_api.esiclient(request).baremetal.ports, details=True)
+                f3 = executor.submit(esi_api.esiclient(request).network.ips)
                 network_ports = list(f1.result())
                 port_name_dict = {port.id: port.name for port in network_ports}
                 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 esisdk>=0.5.0 # Apache-2.0
 horizon>=24.0.0
 metalsmith>=2.3.0
+keystoneauth1>=4.3.1 # Apache-2.0


### PR DESCRIPTION
Using password auth results in a project scoped token; however an OIDC token does not. An unscoped token does not have an attached service catalog, resulting in errors with the ESI connection code. Checking if a token is unscoped, and creating a project scoped token if so, fixes the issue.